### PR TITLE
DCS-1196: Peer test identified that some temporary absences didn't ha…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonService.kt
@@ -39,7 +39,7 @@ class PrisonService(@Autowired private val client: PrisonApiClient, val faker: F
       firstName = faker.name().firstName(),
       lastName = faker.name().lastName(),
       dateOfBirth = faker.date().birthday().toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
-      prisonNumber = if (Random().nextBoolean()) letters.get(1) + letters.get(4) + numbers.get(2) else null,
+      prisonNumber = letters.get(1) + letters.get(4) + numbers.get(2),
       reasonForAbsence = faker.expression("reason")
     )
   }.take((5..20).random()).toList()


### PR DESCRIPTION
…ve a prison number. This shouldn’t ever happen because a current prisoners will always have a number. The fake data generation changed to prevent returning ‘null’ for prison number.