### PR TITLE
DCS-1202 Map BASM move types of expected arrivals API side.  

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/Movement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/Movement.kt
@@ -24,14 +24,13 @@ data class Movement(
   val date: LocalDate,
   @Schema(description = "From Location", example = "Kingston-upon-Hull Crown Court")
   val fromLocation: String,
-  @Schema(description = "Move type", example = "PRISON_REMAND")
-  val moveType: MoveType
+  @Schema(description = "From location type", example = "COURT")
+  val fromLocationType: LocationType,
 )
 
-enum class MoveType {
-  PRISON_REMAND,
-  COURT_APPEARANCE,
-  PRISON_RECALL,
-  VIDEO_REMAND,
-  PRISON_TRANSFER,
+enum class LocationType {
+  COURT,
+  CUSTODY_SUITE,
+  PRISON,
+  OTHER
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/basm/BasmService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/basm/BasmService.kt
@@ -1,10 +1,11 @@
 package uk.gov.justice.digital.hmpps.welcometoprison.model.basm
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.welcometoprison.model.MoveType
+import uk.gov.justice.digital.hmpps.welcometoprison.model.LocationType
 import uk.gov.justice.digital.hmpps.welcometoprison.model.Movement
 import uk.gov.justice.digital.hmpps.welcometoprison.model.basm.Model.Includes
 import uk.gov.justice.digital.hmpps.welcometoprison.model.basm.Model.Location
+import uk.gov.justice.digital.hmpps.welcometoprison.model.basm.Model.MoveType
 import uk.gov.justice.digital.hmpps.welcometoprison.model.basm.Model.People
 import uk.gov.justice.digital.hmpps.welcometoprison.model.basm.Model.Profile
 import java.time.LocalDate
@@ -40,7 +41,7 @@ class BasmService(private val basmClient: BasmClient) {
           it.relationships.from_location.data?.id != null &&
           it.relationships.to_location.data?.id != null &&
           profiles(it.relationships.profile.data.id)?.relationships?.person?.data?.id != null &&
-          it.attributes.move_type != Model.MoveType.PRISON_TRANSFER
+          it.attributes.move_type != MoveType.PRISON_TRANSFER
       }
       .map {
         val fromLocationUuid = it.relationships.from_location.data?.id
@@ -56,9 +57,17 @@ class BasmService(private val basmClient: BasmClient) {
           prisonNumber = personData.prison_number,
           pncNumber = personData.police_national_computer,
           date = it.attributes.date!!,
-          moveType = MoveType.valueOf(it.attributes.move_type.name),
-          fromLocation = locations(fromLocationUuid!!)?.attributes?.title!!
+          fromLocation = locations(fromLocationUuid!!)?.attributes?.title!!,
+          fromLocationType = mapBasmMoveTypeToLocationType(it.attributes.move_type)
         )
       }
+  }
+
+  private fun mapBasmMoveTypeToLocationType(moveType: MoveType): LocationType = when (moveType) {
+    MoveType.PRISON_REMAND -> LocationType.COURT
+    MoveType.PRISON_RECALL -> LocationType.CUSTODY_SUITE
+    MoveType.VIDEO_REMAND -> LocationType.CUSTODY_SUITE
+    MoveType.PRISON_TRANSFER -> LocationType.PRISON
+    else -> LocationType.OTHER
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonService.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.welcometoprison.model.prison
 import com.github.javafaker.Faker
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.welcometoprison.model.MoveType
+import uk.gov.justice.digital.hmpps.welcometoprison.model.LocationType
 import uk.gov.justice.digital.hmpps.welcometoprison.model.Movement
 import uk.gov.justice.digital.hmpps.welcometoprison.model.TemporaryAbsence
 import java.time.LocalDate
@@ -30,7 +30,7 @@ class PrisonService(@Autowired private val client: PrisonApiClient, val faker: F
       prisonNumber = letters.get(1) + letters.get(4) + numbers.get(2),
       pncNumber = numbers.get(4) + "/" + numbers.get(7) + letters.get(1),
       date = date,
-      moveType = MoveType.PRISON_TRANSFER,
+      fromLocationType = LocationType.PRISON,
     )
   }.take((5..20).random()).toList()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/MovementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/MovementServiceTest.kt
@@ -130,6 +130,28 @@ class MovementServiceTest {
       prisonNumber = "A1278AA",
       pncNumber = "1234/1234589A",
       moveType = PRISON_TRANSFER
+      listOf(
+        Movement(
+          firstName = "JIM",
+          lastName = "SMITH",
+          dateOfBirth = LocalDate.of(1991, 7, 31),
+          prisonNumber = "A1234AA",
+          pncNumber = "99/123456J",
+          date = LocalDate.of(2021, 1, 2),
+          fromLocation = "MDI",
+          fromLocationType = LocationType.PRISON
+        ),
+        Movement(
+          firstName = "First",
+          lastName = "Last",
+          dateOfBirth = LocalDate.of(1980, 2, 23),
+          prisonNumber = "A1278AA",
+          pncNumber = "1234/1234589A",
+          date = LocalDate.of(2021, 1, 2),
+          fromLocation = "MDI",
+          fromLocationType = LocationType.PRISON
+        )
+      )
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/MovementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/MovementServiceTest.kt
@@ -5,8 +5,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.welcometoprison.model.MoveType.PRISON_RECALL
-import uk.gov.justice.digital.hmpps.welcometoprison.model.MoveType.PRISON_TRANSFER
 import uk.gov.justice.digital.hmpps.welcometoprison.model.basm.BasmService
 import uk.gov.justice.digital.hmpps.welcometoprison.model.prison.PrisonService
 import uk.gov.justice.digital.hmpps.welcometoprison.model.prisonersearch.PrisonerSearchService
@@ -119,7 +117,7 @@ class MovementServiceTest {
       pncNumber = "99/123456J",
       date = date,
       fromLocation = "MDI",
-      moveType = PRISON_RECALL
+      fromLocationType = LocationType.CUSTODY_SUITE
     )
 
     private val prisonServiceMovement = basmMovement.copy(
@@ -129,29 +127,7 @@ class MovementServiceTest {
       dateOfBirth = LocalDate.of(1980, 2, 23),
       prisonNumber = "A1278AA",
       pncNumber = "1234/1234589A",
-      moveType = PRISON_TRANSFER
-      listOf(
-        Movement(
-          firstName = "JIM",
-          lastName = "SMITH",
-          dateOfBirth = LocalDate.of(1991, 7, 31),
-          prisonNumber = "A1234AA",
-          pncNumber = "99/123456J",
-          date = LocalDate.of(2021, 1, 2),
-          fromLocation = "MDI",
-          fromLocationType = LocationType.PRISON
-        ),
-        Movement(
-          firstName = "First",
-          lastName = "Last",
-          dateOfBirth = LocalDate.of(1980, 2, 23),
-          prisonNumber = "A1278AA",
-          pncNumber = "1234/1234589A",
-          date = LocalDate.of(2021, 1, 2),
-          fromLocation = "MDI",
-          fromLocationType = LocationType.PRISON
-        )
-      )
+      fromLocationType = LocationType.PRISON
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/basm/BasmServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/basm/BasmServiceTest.kt
@@ -4,7 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.welcometoprison.model.MoveType
+import uk.gov.justice.digital.hmpps.welcometoprison.model.LocationType
 import uk.gov.justice.digital.hmpps.welcometoprison.model.Movement
 import java.time.LocalDate
 
@@ -30,7 +30,7 @@ class BasmServiceTest {
           pncNumber = null,
           date = LocalDate.of(2021, 9, 29),
           fromLocation = "Penrith County Court",
-          moveType = MoveType.PRISON_REMAND
+          fromLocationType = LocationType.COURT
         )
       )
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/IncomingMovesResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/IncomingMovesResourceTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.mock.mockito.MockBean
 import uk.gov.justice.digital.hmpps.welcometoprison.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.welcometoprison.model.MoveType
+import uk.gov.justice.digital.hmpps.welcometoprison.model.LocationType
 import uk.gov.justice.digital.hmpps.welcometoprison.model.Movement
 import uk.gov.justice.digital.hmpps.welcometoprison.model.prison.PrisonService
 import uk.gov.justice.digital.hmpps.welcometoprison.utils.LoadJsonHelper.Companion.loadJson
@@ -69,8 +69,8 @@ class IncomingMovesResourceTest : IntegrationTestBase() {
             prisonNumber = "A1278AA",
             pncNumber = "1234/1234589A",
             date = LocalDate.of(2021, 1, 2),
-            moveType = MoveType.PRISON_TRANSFER,
-            fromLocation = "MDI"
+            fromLocation = "MDI",
+            fromLocationType = LocationType.PRISON
           )
         )
       )

--- a/src/test/resources/uk/gov/justice/digital/hmpps/welcometoprison/resource/moves.json
+++ b/src/test/resources/uk/gov/justice/digital/hmpps/welcometoprison/resource/moves.json
@@ -5,7 +5,7 @@
     "dateOfBirth": "1996-07-23",
     "date": "2021-09-29",
     "fromLocation": "Penrith County Court",
-    "moveType": "PRISON_REMAND"
+    "fromLocationType": "COURT"
   },
   {
     "firstName": "First",
@@ -15,6 +15,6 @@
     "pncNumber": "1234/1234589A",
     "date": "2021-01-02",
     "fromLocation": "MDI",
-    "moveType": "PRISON_TRANSFER"
+    "fromLocationType": "PRISON"
   }
 ]


### PR DESCRIPTION
Replace the moveType property of Movements with a fromLocationType of type LocationType.  Mapping from BASM MoveType to LocationType done in BasmService. Reproduces logic currently implemented in the UI.