### PR TITLE
DCS-1459 fixing matching logic during confirmation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/arrivals/ArrivalsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/arrivals/ArrivalsService.kt
@@ -53,11 +53,11 @@ class ArrivalsService(
   ): ConfirmArrivalResponse {
 
     val arrival = getArrival(moveId)
-
+    val prisonNumber = arrival.potentialMatches?.firstOrNull()?.prisonNumber
     return if (!arrival.isCurrentPrisoner)
-      when (arrival.prisonNumber) {
+      when (prisonNumber) {
         null -> createAndAdmitOffender(confirmArrivalDetail, moveId)
-        else -> admitOffender(confirmArrivalDetail, moveId, arrival.prisonNumber)
+        else -> admitOffender(confirmArrivalDetail, moveId, prisonNumber)
       } else
       throw IllegalArgumentException("Confirming arrival of active prisoner: '${arrival.prisonNumber}' is not supported.")
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/ConfirmArrivalDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/ConfirmArrivalDetail.kt
@@ -23,6 +23,16 @@ data class ConfirmArrivalDetail(
   @field:Pattern(regexp = "^([0-9]{2}|[0-9]{4})/[0-9]+[a-zA-Z]$", message = "PNC is not valid")
   val pncNumber: String? = null,
 
+  @Schema(
+    description = "The offender's Prison number.",
+    example = "A1234AA",
+    pattern = "^[A-Za-z]\\d{4}[A-Za-z]{2}\$",
+    maxLength = 7
+  )
+  @field:Length(max = 7)
+  @field:Pattern(regexp = "^[A-Za-z]\\d{4}[A-Za-z]{2}\$", message = "Prison number is not valid")
+  val prisonNumber: String? = null,
+
   @Schema(required = true, description = "The offender's last name.", example = "Mark", maxLength = 35)
   @field:Length(max = 35)
   @field:NotBlank

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/CreateAdmitOffenderResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/CreateAdmitOffenderResponse.kt
@@ -1,3 +1,0 @@
-package uk.gov.justice.digital.hmpps.welcometoprison.model.prison
-
-data class CreateAdmitOffenderResponse(val offenderNo: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/temporaryabsences/TemporaryAbsenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/temporaryabsences/TemporaryAbsenceService.kt
@@ -35,11 +35,11 @@ class TemporaryAbsenceService(
   }
 
   fun confirmTemporaryAbsencesArrival(
-    offenderNo: String,
+    prisonNumber: String,
     confirmTemporaryAbsenceRequest: ConfirmTemporaryAbsenceRequest
   ): ConfirmTemporaryAbsenceResponse {
     val inmateDetail = prisonApiClient.confirmTemporaryAbsencesArrival(
-      offenderNo,
+      prisonNumber,
       with(confirmTemporaryAbsenceRequest) {
         TemporaryAbsencesArrival(
           agencyId,
@@ -50,10 +50,10 @@ class TemporaryAbsenceService(
       }
     )
     val livingUnitName = inmateDetail.assignedLivingUnit?.description
-      ?: throw IllegalArgumentException("Prisoner: '$offenderNo' do not have assigned living unit")
+      ?: throw IllegalArgumentException("Prisoner: '$prisonNumber' do not have assigned living unit")
     return with(inmateDetail) {
       ConfirmTemporaryAbsenceResponse(
-        prisonNumber = offenderNo,
+        prisonNumber = prisonNumber,
         location = locationFormatter.format(livingUnitName)
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resources/TemporaryAbsencesResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resources/TemporaryAbsencesResource.kt
@@ -171,15 +171,15 @@ class TemporaryAbsencesResource(
     ]
   )
   @PostMapping(
-    "/{offenderNo}/confirm",
+    "/{prisonNumber}/confirm",
     consumes = [MediaType.APPLICATION_JSON_VALUE],
     produces = [MediaType.APPLICATION_JSON_VALUE]
   )
   fun temporaryAbsencesArrival(
     @PathVariable
-    offenderNo: String,
+    prisonNumber: String,
 
     @RequestBody
     confirmTemporaryAbsenceRequest: ConfirmTemporaryAbsenceRequest
-  ): ConfirmTemporaryAbsenceResponse = temporaryAbsenceService.confirmTemporaryAbsencesArrival(offenderNo, confirmTemporaryAbsenceRequest)
+  ): ConfirmTemporaryAbsenceResponse = temporaryAbsenceService.confirmTemporaryAbsencesArrival(prisonNumber, confirmTemporaryAbsenceRequest)
 }


### PR DESCRIPTION
We should be reading prison number off first match rather than details from BASM. This allows us to process BASM arrivals that matched on PNC