### PR TITLE
DCS-1473 Using provided prison number as source of truth

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/ConfirmArrivalDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/ConfirmArrivalDetail.kt
@@ -154,4 +154,7 @@ data class ConfirmArrivalDetail(
 ) {
   val youthOffender: Boolean
     get() = Age.lessThanTwentyOneYears(dateOfBirth!!, LocalDate.now())
+
+  val isNewToPrison: Boolean
+    get() = prisonNumber == null
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonService.kt
@@ -4,8 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.welcometoprison.formatter.LocationFormatter
 import uk.gov.justice.digital.hmpps.welcometoprison.model.NotFoundException
-import uk.gov.justice.digital.hmpps.welcometoprison.model.arrivals.Arrival
-import uk.gov.justice.digital.hmpps.welcometoprison.model.prison.courtreturns.ConfirmCourtReturnRequest
 import uk.gov.justice.digital.hmpps.welcometoprison.model.prison.courtreturns.ConfirmCourtReturnResponse
 
 @Service
@@ -83,18 +81,13 @@ class PrisonService(
       )
       .offenderNo
 
-  fun returnFromCourt(
-    confirmCourtReturnRequest: ConfirmCourtReturnRequest,
-    arrival: Arrival
-  ): ConfirmCourtReturnResponse {
+  fun returnFromCourt(prisonId: String, prisonNumber: String): ConfirmCourtReturnResponse {
 
-    var inmateDetail = prisonApiClient.courtTransferIn(
-      arrival.prisonNumber!!,
-      with(confirmCourtReturnRequest) {
-        CourtTransferIn(prisonId!!)
-      }
+    val inmateDetail = prisonApiClient.courtTransferIn(
+      prisonNumber,
+      CourtTransferIn(prisonId)
     )
-    val livingUnitName = inmateDetail.assignedLivingUnit?.description ?: throw IllegalArgumentException("prisoner: '${arrival.prisonNumber}' do not have assigned living unit")
+    val livingUnitName = inmateDetail.assignedLivingUnit?.description ?: throw IllegalArgumentException("prisoner: '$prisonNumber' do not have assigned living unit")
     return ConfirmCourtReturnResponse(
       prisonNumber = inmateDetail.offenderNo,
       location = locationFormatter.format(livingUnitName),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonerDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonerDetails.kt
@@ -24,5 +24,7 @@ data class PrisonerDetails(
   val pncNumber: String?,
 
   @Schema(description = "CRO number", example = "SF80/655108T")
-  val croNumber: String?
+  val croNumber: String?,
+
+  @Transient val isCurrentPrisoner: Boolean
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/courtreturns/ConfirmCourtReturnRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/courtreturns/ConfirmCourtReturnRequest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import org.hibernate.validator.constraints.Length
 import javax.validation.constraints.NotNull
+import javax.validation.constraints.Pattern
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Data for creating an offender record, an associated booking and then adding that offender to a prison's roll")
@@ -12,5 +13,16 @@ data class ConfirmCourtReturnRequest(
   @Schema(description = "Received Prison ID", example = "MDI", required = true)
   @field:Length(max = 3, message = "Prison ID is 3 character code")
   @field:NotNull
-  val prisonId: String? = null
+  val prisonId: String,
+
+  @Schema(
+    description = "The offender's Prison number.",
+    example = "A1234AA",
+    pattern = "^[A-Za-z]\\d{4}[A-Za-z]{2}\$",
+    maxLength = 7
+  )
+  @field:Length(max = 7)
+  @field:Pattern(regexp = "^[A-Za-z]\\d{4}[A-Za-z]{2}\$", message = "Prison number is not valid")
+  @field:NotNull
+  val prisonNumber: String
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/prisonersearch/PrisonerSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/prisonersearch/PrisonerSearchService.kt
@@ -44,6 +44,7 @@ class PrisonerSearchService(@Autowired private val client: PrisonerSearchApiClie
       prisonNumber = prisonNumber,
       pncNumber = prisonerMatch.pncNumber,
       croNumber = prisonerMatch.croNumber,
+      isCurrentPrisoner = prisonerMatch.isCurrentPrisoner
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonServiceTest.kt
@@ -9,10 +9,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.welcometoprison.formatter.LocationFormatter
 import uk.gov.justice.digital.hmpps.welcometoprison.model.NotFoundException
-import uk.gov.justice.digital.hmpps.welcometoprison.model.arrivals.Arrival
-import uk.gov.justice.digital.hmpps.welcometoprison.model.arrivals.Gender
-import uk.gov.justice.digital.hmpps.welcometoprison.model.arrivals.LocationType
-import uk.gov.justice.digital.hmpps.welcometoprison.model.prison.courtreturns.ConfirmCourtReturnRequest
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -149,32 +145,13 @@ class PrisonServiceTest {
 
   @Test
   fun `transferInFromCourt calls prisonApi correctly and returns the bookingId`() {
-    val confirmCourtReturnRequest = ConfirmCourtReturnRequest(
-      prisonId = "MNI"
-    )
-    val arrival = Arrival(
-      id = "0573de83-8a29-42aa-9ede-1068bc433fc5",
-      firstName = "First",
-      lastName = "last",
-      dateOfBirth = LocalDate.of(1978, 1, 1),
-      prisonNumber = "A1234AA",
-      pncNumber = "01/1234X",
-      date = LocalDate.now(),
-      fromLocation = "Kingston-upon-Hull Crown Court",
-      fromLocationType = LocationType.COURT,
-      isCurrentPrisoner = true,
-      gender = Gender.MALE
-    )
     val expectedBookingId = 1L
 
     whenever(prisonApiClient.courtTransferIn(any(), any())).thenReturn(inmateDetail)
 
-    val result = prisonService.returnFromCourt(confirmCourtReturnRequest, arrival)
+    val result = prisonService.returnFromCourt("MNI", "A1234AA")
 
-    verify(prisonApiClient).courtTransferIn(
-      arrival.prisonNumber!!,
-      CourtTransferIn(confirmCourtReturnRequest.prisonId!!)
-    )
+    verify(prisonApiClient).courtTransferIn("A1234AA", CourtTransferIn("MNI"))
     assertThat(result.bookingId).isEqualTo(expectedBookingId)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/prisonersearch/PrisonerSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/prisonersearch/PrisonerSearchServiceTest.kt
@@ -72,7 +72,7 @@ class PrisonerSearchServiceTest {
     val prisoner = service.getPrisoner("A1234AA")
 
     assertThat(prisoner).isEqualTo(
-      PrisonerDetails(FIRST_NAME, LAST_NAME, DOB, PRISON_NUMBER, PNC_NUMBER, CRO_NUMBER)
+      PrisonerDetails(FIRST_NAME, LAST_NAME, DOB, PRISON_NUMBER, PNC_NUMBER, CRO_NUMBER, false)
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/CourtReturnsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/CourtReturnsResourceTest.kt
@@ -17,9 +17,7 @@ class CourtReturnsResourceTest : IntegrationTestBase() {
   @MockBean
   private lateinit var arrivalsService: ArrivalsService
 
-  private val confirmCourtReturnRequest = ConfirmCourtReturnRequest(
-    "NMI"
-  )
+  private val confirmCourtReturnRequest = ConfirmCourtReturnRequest("NMI", "A1234AA")
   private val moveId = "06274b73-6aa9-490e-ab0e-2a25b3638068"
   private val url = "/court-returns/$moveId/confirm"
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/PrisonResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/PrisonResourceTest.kt
@@ -172,7 +172,8 @@ class PrisonResourceTest : IntegrationTestBase() {
           dateOfBirth = LocalDate.of(1970, 12, 25),
           prisonNumber = "A1234BC",
           pncNumber = "11/1234",
-          croNumber = "12/4321"
+          croNumber = "12/4321",
+          isCurrentPrisoner = false
         )
       )
 


### PR DESCRIPTION
Users can select which prisoner refers to a specific incoming move, so now we can't use details we derived from the move itself