### PR TITLE
DCS-1673 fixing issues with missing agency id

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClient.kt
@@ -101,7 +101,6 @@ data class Movement(
  */
 data class InmateDetail(
   val bookingId: Long,
-  val agencyId: String,
   val offenderNo: String,
   val assignedLivingUnit: AssignedLivingUnit? = null
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/temporaryabsences/ConfirmTemporaryAbsenceRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/temporaryabsences/ConfirmTemporaryAbsenceRequest.kt
@@ -11,12 +11,12 @@ import javax.validation.constraints.NotNull
 @Schema(description = "Data for confirming offender return from temporary absence to the prison roll")
 data class ConfirmTemporaryAbsenceRequest(
   @Schema(
-    description = "Agency Id where offender return",
+    description = "Prison Id where offender return",
     example = "MDI",
   )
-  @field:Length(max = 20, min = 2, message = "Agency identifier cannot be less then 2 and more than 20 characters")
+  @field:Length(max = 20, min = 2, message = "Prison identifier cannot be less then 2 and more than 20 characters")
   @field:NotNull
-  val agencyId: String,
+  val prisonId: String,
 
   @Schema(
     description = "Movement Reason Code",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/temporaryabsences/TemporaryAbsenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/temporaryabsences/TemporaryAbsenceService.kt
@@ -41,7 +41,7 @@ class TemporaryAbsenceService(
     val inmateDetail = prisonApiClient.confirmTemporaryAbsencesArrival(prisonNumber, request.toArrival())
     arrivalListener.arrived(
       ArrivalEvent(
-        prisonId = inmateDetail.agencyId,
+        prisonId = request.prisonId,
         prisonNumber = inmateDetail.offenderNo,
         bookingId = inmateDetail.bookingId,
         arrivalType = TEMPORARY_ABSENCE,
@@ -51,6 +51,6 @@ class TemporaryAbsenceService(
   }
 
   private fun ConfirmTemporaryAbsenceRequest.toArrival() = TemporaryAbsencesArrival(
-    agencyId, movementReasonCode, commentText, receiveTime
+    prisonId, movementReasonCode, commentText, receiveTime
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/transfers/TransferInDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/transfers/TransferInDetail.kt
@@ -5,10 +5,19 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.hibernate.validator.constraints.Length
 import org.springframework.format.annotation.DateTimeFormat
 import java.time.LocalDateTime
+import javax.validation.constraints.NotNull
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Data for creating transferring in an offender and adding to the prison roll")
 data class TransferInDetail(
+  @Schema(
+    description = "Prison Id where offender return",
+    example = "MDI",
+  )
+  @field:Length(max = 20, min = 2, message = "Prison identifier cannot be less then 2 and more than 20 characters")
+  @field:NotNull
+  val prisonId: String,
+
   @Schema(
     description = "Cell location where transferred prisoner should be housed, default will be reception",
     example = "MDI-RECP",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/transfers/TransfersService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/transfers/TransfersService.kt
@@ -49,7 +49,7 @@ class TransfersService(
     val inmateDetail = prisonApiClient.transferIn(prisonNumber, transferInDetail.toArrival())
     arrivalListener.arrived(
       ArrivalEvent(
-        prisonId = inmateDetail.agencyId,
+        prisonId = transferInDetail.prisonId,
         prisonNumber = inmateDetail.offenderNo,
         bookingId = inmateDetail.bookingId,
         arrivalType = TRANSFER,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/arrivals/ConfirmationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/arrivals/ConfirmationServiceTest.kt
@@ -349,13 +349,13 @@ class ConfirmationServiceTest {
 
     private val LOCATION = "RECP"
     private val INMATE_DETAIL = InmateDetail(
-      offenderNo = PRISON_NUMBER, bookingId = BOOKING_ID, agencyId = PRISON_ID,
+      offenderNo = PRISON_NUMBER, bookingId = BOOKING_ID,
       assignedLivingUnit = AssignedLivingUnit(
         PRISON_ID, LOCATION_ID, LOCATION, "Nottingham (HMP)"
       )
     )
     private val INMATE_DETAIL_NO_UNIT = InmateDetail(
-      offenderNo = PRISON_NUMBER, bookingId = BOOKING_ID, agencyId = PRISON_ID
+      offenderNo = PRISON_NUMBER, bookingId = BOOKING_ID
     )
     private val CONFIRM_COURT_RETURN_RESPONSE =
       ConfirmCourtReturnResponse(prisonNumber = PRISON_NUMBER, location = LOCATION, bookingId = BOOKING_ID)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonServiceTest.kt
@@ -22,7 +22,6 @@ class PrisonServiceTest {
   private val inmateDetailNewBooking = InmateDetail(
     offenderNo = "ABC123A",
     bookingId = 1L,
-    agencyId = "NMI"
   )
   private val inmateDetail = InmateDetail(
     offenderNo = "ABC123A",
@@ -32,8 +31,7 @@ class PrisonServiceTest {
       1,
       "RECP",
       "Nottingham (HMP)"
-    ),
-    agencyId = "NMI"
+    )
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/temporaryAbsences/TemporaryAbsenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/temporaryAbsences/TemporaryAbsenceServiceTest.kt
@@ -26,7 +26,7 @@ class TemporaryAbsenceServiceTest {
   private val arrivalListener: ArrivalListener = mock()
   private val temporaryAbsenceService = TemporaryAbsenceService(prisonApiClient, locationFormatter, arrivalListener)
   private val inmateDetail = InmateDetail(
-    offenderNo = "G6081VQ", bookingId = 1L, agencyId = "NMI",
+    offenderNo = "G6081VQ", bookingId = 1L,
     assignedLivingUnit = AssignedLivingUnit(
       "NMI", 1, "RECP", "Nottingham (HMP)"
     )
@@ -85,7 +85,7 @@ class TemporaryAbsenceServiceTest {
   fun `confirm temporary absence`() {
     whenever(prisonApiClient.confirmTemporaryAbsencesArrival(any(), any())).thenReturn(inmateDetail)
 
-    val request = ConfirmTemporaryAbsenceRequest(agencyId = "MDI", movementReasonCode = "C")
+    val request = ConfirmTemporaryAbsenceRequest(prisonId = "MDI", movementReasonCode = "C")
     assertThat(
       temporaryAbsenceService.confirmTemporaryAbsencesArrival("A1234AA", request)
     ).isEqualTo(ConfirmTemporaryAbsenceResponse(prisonNumber = "A1234AA", location = "Reception"))
@@ -97,14 +97,14 @@ class TemporaryAbsenceServiceTest {
   fun `confirm temporary absence recorded as arrival event`() {
     whenever(prisonApiClient.confirmTemporaryAbsencesArrival(any(), any())).thenReturn(inmateDetail)
 
-    val request = ConfirmTemporaryAbsenceRequest(agencyId = "MDI", movementReasonCode = "C")
+    val request = ConfirmTemporaryAbsenceRequest(prisonId = "MDI", movementReasonCode = "C")
     assertThat(
       temporaryAbsenceService.confirmTemporaryAbsencesArrival("A1234AA", request)
     ).isEqualTo(ConfirmTemporaryAbsenceResponse(prisonNumber = "A1234AA", location = "Reception"))
 
     verify(arrivalListener).arrived(
       ArrivalEvent(
-        prisonId = inmateDetail.agencyId,
+        prisonId = "MDI",
         prisonNumber = inmateDetail.offenderNo,
         arrivalType = ArrivalType.TEMPORARY_ABSENCE,
         bookingId = inmateDetail.bookingId

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/transfers/TransfersServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/transfers/TransfersServiceTest.kt
@@ -32,7 +32,7 @@ class TransfersServiceTest {
     TransfersService(prisonApiClient, prisonerSearchService, locationFormatter, arrivalListener)
 
   private val inmateDetail = InmateDetail(
-    offenderNo = "G6081VQ", bookingId = 1L, agencyId = "NMI",
+    offenderNo = "G6081VQ", bookingId = 1L,
     assignedLivingUnit = AssignedLivingUnit(
       "NMI", 1, "RECP", "Nottingham (HMP)"
     )
@@ -118,6 +118,7 @@ class TransfersServiceTest {
   fun `transfer-in offender`() {
 
     val transferInDetail = TransferInDetail(
+      prisonId = "MDI",
       cellLocation = "MDI-RECP",
       commentText = "some transfer notes",
       receiveTime = LocalDateTime.now()
@@ -138,12 +139,12 @@ class TransfersServiceTest {
 
     transfersService.transferInOffender(
       "ABC123A",
-      TransferInDetail("MDI-RECP", "some transfer notes", LocalDateTime.now())
+      TransferInDetail("MDI", "MDI-RECP", "some transfer notes", LocalDateTime.now())
     )
 
     verify(arrivalListener).arrived(
       ArrivalEvent(
-        prisonId = inmateDetail.agencyId,
+        prisonId = "MDI",
         prisonNumber = inmateDetail.offenderNo,
         arrivalType = TRANSFER,
         bookingId = inmateDetail.bookingId
@@ -157,6 +158,7 @@ class TransfersServiceTest {
     val inmate = inmateDetail.copy(assignedLivingUnit = null, offenderNo = "G6081VQ")
 
     val transferInDetail = TransferInDetail(
+      prisonId = "MDI",
       cellLocation = "MDI-RECP",
       commentText = "some transfer notes",
       receiveTime = LocalDateTime.now()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/TransfersResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/TransfersResourceTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.welcometoprison.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.welcometoprison.model.prison.TransferIn
 import uk.gov.justice.digital.hmpps.welcometoprison.model.prison.prisonersearch.response.PrisonerAndPncNumber
 import uk.gov.justice.digital.hmpps.welcometoprison.model.prison.transfers.TransferInDetail
 import uk.gov.justice.digital.hmpps.welcometoprison.utils.loadJson
@@ -22,7 +23,10 @@ class TransfersResourceTest : IntegrationTestBase() {
     @BeforeEach
     fun beforeEach() {
       prisonApiMockServer.stubGetPrisonTransfersEnRoute("MDI")
-      prisonerSearchMockServer.stubMatchByPrisonerNumbers(200, listOf(PrisonerAndPncNumber(prisonerNumber = "A1278AA", pncNumber = "1234/1234589A")))
+      prisonerSearchMockServer.stubMatchByPrisonerNumbers(
+        200,
+        listOf(PrisonerAndPncNumber(prisonerNumber = "A1278AA", pncNumber = "1234/1234589A"))
+      )
     }
 
     @Test
@@ -79,7 +83,10 @@ class TransfersResourceTest : IntegrationTestBase() {
     @BeforeEach
     fun beforeEach() {
       prisonApiMockServer.stubGetPrisonTransfersEnRoute("MDI")
-      prisonerSearchMockServer.stubMatchByPrisonerNumbers(200, listOf(PrisonerAndPncNumber(prisonerNumber = "A1278AA", pncNumber = "1234/1234589A")))
+      prisonerSearchMockServer.stubMatchByPrisonerNumbers(
+        200,
+        listOf(PrisonerAndPncNumber(prisonerNumber = "A1278AA", pncNumber = "1234/1234589A"))
+      )
     }
 
     @Test
@@ -132,6 +139,7 @@ class TransfersResourceTest : IntegrationTestBase() {
 
   companion object {
     val transferInDetail = TransferInDetail(
+      "MDI",
       "MDI-RECP",
       "some comment",
       LocalDateTime.of(2021, 11, 15, 1, 0, 0)
@@ -166,7 +174,7 @@ class TransfersResourceTest : IntegrationTestBase() {
     fun `Should call prison service with correct args`() {
       prisonApiMockServer.stubTransferInOffender("A1234BC")
 
-      val transferInDetails = TransferInDetail(
+      val transferIn = TransferIn(
         "MDI-RECP",
         "some comment",
         LocalDateTime.of(2021, 11, 15, 1, 0, 0)
@@ -191,7 +199,7 @@ class TransfersResourceTest : IntegrationTestBase() {
             "/api/offenders/A1234BC/transfer-in"
           )
         ).withHeader("Authorization", equalTo(token))
-          .withRequestBody(equalToJson(objectMapper.writeValueAsString(transferInDetails)))
+          .withRequestBody(equalToJson(objectMapper.writeValueAsString(transferIn)))
       )
     }
   }


### PR DESCRIPTION
For some calls agency id was missing from incoming inmate details, this moves to using the id provided by the frontend as the source of truth