### PR TITLE
DCS-1836 Handle null prisoner statuses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/prisonersearch/PrisonerDetailsConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/prisonersearch/PrisonerDetailsConverter.kt
@@ -51,6 +51,7 @@ fun MatchPrisonerResponse.toPotentialMatch() = PotentialMatch(
 private fun MatchPrisonerResponse.buildArrivalDescription() = "$status-$lastMovementTypeCode-$prisonId"
 
 fun MatchPrisonerResponse.calculateArrivalType() = when (status) {
+  null -> NEW_BOOKING
   "INACTIVE TRN" -> TRANSFER
   "INACTIVE OUT" -> NEW_BOOKING
   "ACTIVE IN" -> CURRENTLY_IN

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/prisonersearch/response/MatchPrisonerResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/prisonersearch/response/MatchPrisonerResponse.kt
@@ -18,7 +18,8 @@ data class MatchPrisonerResponse(
   val pncNumber: String?,
   val croNumber: String?,
   val gender: String,
-  val status: String,
+  // Status can be null when a prison record has no associated bookings
+  val status: String?,
   val lastMovementTypeCode: String,
   val prisonId: String,
 ) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/prisonersearch/PrisonerDetailsConverterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/prisonersearch/PrisonerDetailsConverterTest.kt
@@ -15,7 +15,7 @@ import java.time.LocalDate
 
 class PrisonerDetailsConverterTest {
 
-  fun whenever(status: String, moveType: String = "") = MatchPrisonerResponse(
+  fun whenever(status: String?, moveType: String = "") = MatchPrisonerResponse(
     firstName = "FIRST_NAME",
     lastName = "LAST_NAME",
     dateOfBirth = LocalDate.of(2000, 1, 1),
@@ -65,6 +65,11 @@ class PrisonerDetailsConverterTest {
     @Test
     fun `from court`() {
       whenever(status = "ACTIVE OUT", moveType = "CRT") `then arrival type is` FROM_COURT
+    }
+
+    @Test
+    fun `record with no status`() {
+      whenever(status = null) `then arrival type is` NEW_BOOKING
     }
   }
 


### PR DESCRIPTION
Bit of an edge case when a prison record has been created but has no booking, prisoner-offender-search will return a null status. We will want to process these as requiring a new booking