### PR TITLE
DCS-1885 removed old get temp absence endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resources/TemporaryAbsencesResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resources/TemporaryAbsencesResource.kt
@@ -126,12 +126,10 @@ class TemporaryAbsencesResource(
   )
   @GetMapping(
     path = [
-      "/prison/{prisonId}/temporary-absences/{prisonNumber}", "/temporary-absences/{prisonNumber}"
+      "/temporary-absences/{prisonNumber}"
     ]
   )
   fun getTemporaryAbsence(
-    @Schema(description = "Prison ID", example = "MDI", required = false)
-    @PathVariable prisonId: String?,
     @Schema(description = "Prison Number", example = "A1234AA", required = true)
     @PathVariable prisonNumber: String
   ): TemporaryAbsenceResponse = temporaryAbsenceService.getTemporaryAbsence(prisonNumber)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/TemporaryAbsencesResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/TemporaryAbsencesResourceTest.kt
@@ -45,14 +45,14 @@ class TemporaryAbsencesResourceTest : IntegrationTestBase() {
 
     @Test
     fun `requires authentication`() {
-      webTestClient.get().uri("/prison/MDI/temporary-absences/A1234AA")
+      webTestClient.get().uri("/temporary-absences/A1234AA")
         .exchange()
         .expectStatus().isUnauthorized
     }
 
     @Test
     fun `requires correct role`() {
-      webTestClient.get().uri("/prison/MDI/temporary-absences/A1234AA")
+      webTestClient.get().uri("/temporary-absences/A1234AA")
         .headers(setAuthorisation(roles = listOf(), scopes = listOf("read")))
         .exchange()
         .expectStatus().isForbidden
@@ -60,19 +60,7 @@ class TemporaryAbsencesResourceTest : IntegrationTestBase() {
     }
 
     @Test
-    @Deprecated("endpoint to be removed following update in frontend")
     fun `returns json in expected format`() {
-      prisonerSearchMockServer.stubGetPrisoner(200)
-      prisonApiMockServer.stubGetTemporaryAbsencesWithTwoRecords("MDI")
-      webTestClient.get().uri("/prison/MDI/temporary-absences/A1234AA")
-        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_ARRIVALS"), scopes = listOf("read")))
-        .exchange()
-        .expectStatus().isOk
-        .expectBody().json("temporaryAbsence".loadJson(this))
-    }
-
-    @Test
-    fun `when calling endpoint without prisonId returns json in expected format`() {
       prisonerSearchMockServer.stubGetPrisoner(200)
       prisonApiMockServer.stubGetTemporaryAbsencesWithTwoRecords("MDI")
       webTestClient.get().uri("/temporary-absences/A1234AA")


### PR DESCRIPTION
Removed now deprecated `/prison/{prisonId}/temporary-absences/{prisonNumber}` endpoint, replaced by `/temporary-absences/{prisonNumber}`, to enable a user to retrieve a temporary absence from another prison without the service blowing up. 