### PR TITLE
DCS-2043 making field mandatory

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/arrivals/Arrival.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/arrivals/Arrival.kt
@@ -63,7 +63,7 @@ data class PotentialMatch(
   val dateOfBirth: LocalDate,
 
   @Schema(description = "Prison number", example = "A1234AA")
-  val prisonNumber: String?,
+  val prisonNumber: String,
 
   @Schema(description = "PNC number", example = "01/1234X")
   val pncNumber: String?,


### PR DESCRIPTION
The API representation from prisoner-offender-search already had this as mandatory so its a safe fix