### PR TITLE
DCS-1844 Create booking at the same time as new offender

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/arrivals/ConfirmationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/arrivals/ConfirmationService.kt
@@ -99,8 +99,7 @@ class ConfirmationService(
   }
 
   private fun createAndAdmitOffender(confirmation: Confirmation): ConfirmArrivalResponse {
-    val prisonNumber = prisonService.createOffender(confirmation.detail)
-    val result = prisonService.admitOffenderOnNewBooking(prisonNumber, confirmation.detail)
+    val result = prisonService.createOffender(confirmation.detail)
 
     arrivalListener.arrived(confirmation.toEvent(result, NEW_TO_PRISON))
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClient.kt
@@ -26,7 +26,8 @@ data class CreateOffenderDetail(
   val croNumber: String? = null,
   val pncNumber: String? = null,
   val suffix: String? = null,
-  val title: String? = null
+  val title: String? = null,
+  val booking: AdmitOnNewBookingDetail? = null
 )
 
 data class AdmitOnNewBookingDetail(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonService.kt
@@ -53,7 +53,7 @@ class PrisonService(
       }
     )
 
-  fun createOffender(confirmArrivalDetail: ConfirmArrivalDetail): String =
+  fun createOffender(confirmArrivalDetail: ConfirmArrivalDetail): InmateDetail =
     prisonApiClient
       .createOffender(
         with(confirmArrivalDetail) {
@@ -63,10 +63,16 @@ class PrisonService(
             dateOfBirth = dateOfBirth!!,
             gender = sex!!,
             pncNumber = pncNumber,
+            booking = AdmitOnNewBookingDetail(
+              prisonId = prisonId!!,
+              fromLocationId = fromLocationId,
+              movementReasonCode = movementReasonCode!!,
+              youthOffender = youthOffender,
+              imprisonmentStatus = imprisonmentStatus!!
+            )
           )
         }
       )
-      .offenderNo
 
   fun returnFromCourt(prisonId: String, prisonNumber: String): ConfirmCourtReturnResponse {
     val inmateDetail = prisonApiClient.courtTransferIn(prisonNumber, CourtTransferIn(prisonId))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
@@ -212,9 +212,9 @@ class PrisonApiMockServer : WireMockServer(9005) {
     )
   }
 
-  fun stubAdmitOnNewBookingFailsNoCapacity(offenderNo: String) {
+  fun stubAdmitOnNewBookingFailsNoCapacity() {
     stubFor(
-      post("/api/offenders/$offenderNo/booking")
+      post("/api/offenders")
         .willReturn(
           aResponse()
             .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/arrivals/ConfirmationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/arrivals/ConfirmationServiceTest.kt
@@ -50,8 +50,7 @@ class ConfirmationServiceTest {
 
   @Test
   fun `Confirm arrival not known to NOMIS`() {
-    whenever(prisonService.createOffender(any())).thenReturn(PRISON_NUMBER)
-    whenever(prisonService.admitOffenderOnNewBooking(any(), any())).thenReturn(INMATE_DETAIL)
+    whenever(prisonService.createOffender(any())).thenReturn(INMATE_DETAIL)
 
     val response =
       confirmationService.confirmArrival(
@@ -65,10 +64,6 @@ class ConfirmationServiceTest {
 
     inOrder(prisonService) {
       verify(prisonService).createOffender(CONFIRMED_ARRIVAL_DETAIL_PROTOTYPE.copy(prisonNumber = null))
-      verify(prisonService).admitOffenderOnNewBooking(
-        PRISON_NUMBER,
-        CONFIRMED_ARRIVAL_DETAIL_PROTOTYPE.copy(prisonNumber = null)
-      )
     }
 
     verify(arrivalListener).arrived(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/UnexpectedArrivalsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/UnexpectedArrivalsResourceTest.kt
@@ -31,7 +31,6 @@ class UnexpectedArrivalsResourceTest : IntegrationTestBase() {
       val prisonNumber = "AA1111A"
       val location = "Reception"
       prisonApiMockServer.stubCreateOffender(prisonNumber)
-      prisonApiMockServer.stubAdmitOnNewBooking(prisonNumber)
 
       webTestClient
         .post()
@@ -51,7 +50,6 @@ class UnexpectedArrivalsResourceTest : IntegrationTestBase() {
       val prisonNumber = "AA1111A"
 
       prisonApiMockServer.stubCreateOffender(prisonNumber)
-      prisonApiMockServer.stubAdmitOnNewBooking(prisonNumber)
 
       val token = getAuthorisation(roles = listOf("ROLE_BOOKING_CREATE", "ROLE_TRANSFER_PRISONER"), scopes = listOf("read", "write"))
 
@@ -79,7 +77,6 @@ class UnexpectedArrivalsResourceTest : IntegrationTestBase() {
       val prisonNumber = "AA1111A"
 
       prisonApiMockServer.stubCreateOffender(prisonNumber)
-      prisonApiMockServer.stubAdmitOnNewBooking(prisonNumber)
 
       webTestClient
         .post()
@@ -143,54 +140,8 @@ class UnexpectedArrivalsResourceTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `create and book - prison-api create booking fails`() {
-      val prisonNumber = "AA1111A"
-
-      prisonApiMockServer.stubCreateOffender(prisonNumber)
-      prisonApiMockServer.stubAdmitOnNewBookingFails(prisonNumber, 500)
-
-      webTestClient
-        .post()
-        .uri("/unexpected-arrivals/confirm")
-        .headers(setAuthorisation(roles = listOf("ROLE_BOOKING_CREATE", "ROLE_TRANSFER_PRISONER"), scopes = listOf("read", "write")))
-        .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-        .bodyValue(VALID_REQUEST)
-        .exchange()
-        .expectStatus().is5xxServerError
-        .expectBody()
-    }
-
-    @Test
-    fun `create and book - prison-api create booking fails because of no capacity`() {
-      val prisonNumber = "AA1111A"
-
-      prisonApiMockServer.stubCreateOffender(prisonNumber)
-      prisonApiMockServer.stubAdmitOnNewBookingFailsNoCapacity(prisonNumber)
-
-      webTestClient
-        .post()
-        .uri("/unexpected-arrivals/confirm")
-        .headers(setAuthorisation(roles = listOf("ROLE_BOOKING_CREATE", "ROLE_TRANSFER_PRISONER"), scopes = listOf("read", "write")))
-        .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-        .bodyValue(VALID_REQUEST)
-        .exchange()
-        .expectStatus().is4xxClientError
-        .expectBody().json(
-          """
-        {
-          "status": 409,
-          "errorCode": "NO_CELL_CAPACITY",
-          "moreInfo": null
-        }
-          """.trimIndent()
-        )
-    }
-    @Test
     fun `create and book - prison-api create booking fails because prisoner already exist`() {
-      val prisonNumber = "AA1111A"
-
       prisonApiMockServer.stubCreateOffenderFailsPrisonerAlreadyExist()
-      prisonApiMockServer.stubAdmitOnNewBooking(prisonNumber)
 
       webTestClient
         .post()


### PR DESCRIPTION
Previously this was done as two separate calls. These calls could fail independently. 

This now performs both operations at the same time