### PR TITLE
MAP-832 updated dependency to fix CVE

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
   implementation("commons-codec:commons-codec:1.16.1")
 
   runtimeOnly("org.flywaydb:flyway-core")
-  runtimeOnly("org.postgresql:postgresql:42.7.1")
+  runtimeOnly("org.postgresql:postgresql:42.7.2")
   testRuntimeOnly("com.h2database:h2:2.2.224")
 
   testImplementation("org.wiremock:wiremock-standalone:3.4.1")


### PR DESCRIPTION
to fix


```Severity: CRITICAL
CVE: CVE-2024-1597
Title: "pgjdbc, the PostgreSQL JDBC Driver, allows attacker to inject SQL if u ..."
PkgName: org.postgresql:postgresql
InstalledVersion: 42.7.1
FixedVersion: 42.2.28, 42.3.9, 42.4.4, 42.5.5, 42.6.1, 42.7.2
Location: Java```
