### PR TITLE
MAP-1460 31 PrisonApiClientTest Telemetry red coverage

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
@@ -728,6 +728,26 @@ class PrisonApiMockServer : WireMockServer(9005) {
     )
   }
 
+  fun stubErrorTemporaryAbsencesSuccess(offenderNo: String, status: Int) {
+    stubFor(
+      put("/api/offenders/$offenderNo/temporary-absence-arrival")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .withStatus(status)
+            .withBody(
+              """
+              {
+                "status": $status,
+                "userMessage": "No prisoner found for prisoner number A1234BC",
+                "developerMessage": "No prisoner found for prisoner number A1234BC"
+              }
+            """,
+            ),
+        ),
+    )
+  }
+
   fun stubGetMovementSuccess(agencyId: String, fromDate: LocalDateTime, toDate: LocalDateTime) {
     stubFor(
       get(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
@@ -455,4 +455,26 @@ class PrisonApiClientTest {
     )
     assertThat(response.offenderNo).isEqualTo(offenderNumber)
   }
+
+  @Test
+  fun `return from temporary absences fails`() {
+    val offenderNumber = "ABC123A"
+
+    mockServer.stubErrorTemporaryAbsencesSuccess(offenderNumber, 400)
+    try {
+      val response = prisonApiClient.confirmTemporaryAbsencesArrival(
+        offenderNumber,
+        TemporaryAbsencesArrival(
+          agencyId = "NMI",
+          movementReasonCode = "ET",
+          commentText = "",
+          receiveTime = LocalDateTime.of(2021, 11, 15, 1, 0, 0),
+        ),
+      )
+      assertThat(response.offenderNo).isEqualTo(offenderNumber)
+    } catch (exception: Exception) {
+    }
+
+    verify(telemetryClient).trackEvent(eq("PrisonApiClientError"), any(), eq(null))
+  }
 }


### PR DESCRIPTION
confirmTemporaryAbsencesArrival method wasn't covered for Telemetry propagation when  Error scenario happens

before,
![image](https://github.com/user-attachments/assets/09052bb5-9f8f-49c6-83fa-7e251c54e96d)

after,
![image](https://github.com/user-attachments/assets/a6e3c08c-f3a8-4b8f-9104-7d1ce8ff236c)
