### PR TITLE
MAP-1460 32 createOffender without AssignedLivingUnit

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
@@ -78,6 +78,38 @@ class PrisonApiMockServer : WireMockServer(9005) {
     )
   }
 
+  fun stubCreateOffenderWithoutAssignedLivingUnit(offenderNo: String) {
+    stubFor(
+      post("/api/offenders")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .withStatus(200)
+            .withBody(
+              """
+                {
+                  "offenderNo": "$offenderNo",
+                  "offenderId": 2582523,
+                  "rootOffenderId": 2582523,
+                  "firstName": "D",
+                  "lastName": "RAP",
+                  "dateOfBirth": "1961-01-04",
+                  "age": 60,
+                 "agencyId": "NMI",
+                  "activeFlag": false
+                  },
+                  "physicalAttributes": {
+                    "sexCode": "F",
+                    "gender": "Female"
+                  },
+                  "identifiers": []
+                }
+              """.trimIndent(),
+            ),
+        ),
+    )
+  }
+
   fun stubCreateOffenderFails(status: Int) {
     stubFor(
       post("/api/offenders")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
@@ -160,6 +160,26 @@ class PrisonApiClientTest {
     )
 
     assertThat(response.offenderNo).isEqualTo(offenderNumber)
+    assertThat(response.assignedLivingUnit).isNotNull
+  }
+
+  @Test
+  fun `create offender without assigned living unit`() {
+    val offenderNumber = "ABC123A"
+
+    mockServer.stubCreateOffenderWithoutAssignedLivingUnit(offenderNumber)
+
+    val response = prisonApiClient.createOffender(
+      CreateOffenderDetail(
+        firstName = "A",
+        lastName = "Z",
+        dateOfBirth = LocalDate.of(1961, 5, 29),
+        gender = "M",
+      ),
+    )
+
+    assertThat(response.offenderNo).isEqualTo(offenderNumber)
+    assertThat(response.assignedLivingUnit).isNull()
   }
 
   @Test
@@ -174,7 +194,8 @@ class PrisonApiClientTest {
           gender = "M",
         ),
       )
-    } catch (exception: Exception) {
+    } catch (exception: RuntimeException) {
+      assertThat(exception.message)
     }
 
     verify(telemetryClient).trackEvent(eq("PrisonApiClientError"), any(), eq(null))


### PR DESCRIPTION
InmateDetail DataClass is returned by api/offenders in the body however there is an scenario where assignedLivingUnit can be null and it wasn't covered