### PR TITLE
MAP-1460 31 PrisonApiClientTest Telemetry red coverage

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
@@ -760,6 +760,26 @@ class PrisonApiMockServer : WireMockServer(9005) {
     )
   }
 
+  fun stubErrorTemporaryAbsencesSuccess(offenderNo: String, status: Int) {
+    stubFor(
+      put("/api/offenders/$offenderNo/temporary-absence-arrival")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .withStatus(status)
+            .withBody(
+              """
+              {
+                "status": $status,
+                "userMessage": "No prisoner found for prisoner number A1234BC",
+                "developerMessage": "No prisoner found for prisoner number A1234BC"
+              }
+            """,
+            ),
+        ),
+    )
+  }
+
   fun stubGetMovementSuccess(agencyId: String, fromDate: LocalDateTime, toDate: LocalDateTime) {
     stubFor(
       get(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
@@ -771,8 +771,8 @@ class PrisonApiMockServer : WireMockServer(9005) {
               """
               {
                 "status": $status,
-                "userMessage": "No prisoner found for prisoner number A1234BC",
-                "developerMessage": "No prisoner found for prisoner number A1234BC"
+                "userMessage": "No prisoner found for prisoner number $offenderNo",
+                "developerMessage": "No prisoner found for prisoner number $offenderNo"
               }
             """,
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
@@ -478,6 +478,28 @@ class PrisonApiClientTest {
   }
 
   @Test
+  fun `return from temporary absences fails`() {
+    val offenderNumber = "ABC123A"
+
+    mockServer.stubErrorTemporaryAbsencesSuccess(offenderNumber, 400)
+    try {
+      val response = prisonApiClient.confirmTemporaryAbsencesArrival(
+        offenderNumber,
+        TemporaryAbsencesArrival(
+          agencyId = "NMI",
+          movementReasonCode = "ET",
+          commentText = "",
+          receiveTime = LocalDateTime.of(2021, 11, 15, 1, 0, 0),
+        ),
+      )
+      assertThat(response.offenderNo).isEqualTo(offenderNumber)
+    } catch (exception: Exception) {
+    }
+
+    verify(telemetryClient).trackEvent(eq("PrisonApiClientError"), any(), eq(null))
+  }
+
+  @Test
   fun `Confirm get Agency Test`() {
     val agencyId = "AGE1"
     mockServer.stubGetAgencySuccess(agencyId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
@@ -482,8 +482,8 @@ class PrisonApiClientTest {
     val offenderNumber = "ABC123A"
 
     mockServer.stubErrorTemporaryAbsencesSuccess(offenderNumber, 400)
-    try {
-      val response = prisonApiClient.confirmTemporaryAbsencesArrival(
+    runCatching {
+      prisonApiClient.confirmTemporaryAbsencesArrival(
         offenderNumber,
         TemporaryAbsencesArrival(
           agencyId = "NMI",
@@ -492,8 +492,8 @@ class PrisonApiClientTest {
           receiveTime = LocalDateTime.of(2021, 11, 15, 1, 0, 0),
         ),
       )
-      assertThat(response.offenderNo).isEqualTo(offenderNumber)
-    } catch (exception: Exception) {
+    }.onFailure {
+      assertThat(it.localizedMessage).contains("No prisoner found for prisoner number $offenderNumber")
     }
 
     verify(telemetryClient).trackEvent(eq("PrisonApiClientError"), any(), eq(null))


### PR DESCRIPTION
confirmTemporaryAbsencesArrival method wasn't covered for Telemetry propagation when Error scenario happens

before,
![image](https://github.com/user-attachments/assets/4bceca13-73b4-423f-85f6-5a18a90ada72)

after,
![image](https://github.com/user-attachments/assets/2007f46d-002b-4e31-808e-f9042666eb17)



