### PR TITLE
MAP-1460 PrisonApiClient getMovement EmptyList When Server Error 404

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClient.kt
@@ -10,7 +10,6 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.config.ClientErrorResponse
 import uk.gov.justice.digital.hmpps.config.ClientException
-import uk.gov.justice.digital.hmpps.config.NotFoundException
 import uk.gov.justice.digital.hmpps.config.typeReference
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -306,8 +305,5 @@ class PrisonApiClient(
       .header("Page-Limit", "10000")
       .retrieve()
       .bodyToMono(typeReference<List<Movement>>())
-      .onErrorResume(WebClientResponseException::class.java) {
-        throw NotFoundException("Could not find agency with agencyId: '$agencyId'")
-      }
       .block() ?: emptyList()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClient.kt
@@ -300,10 +300,13 @@ class PrisonApiClient(
       .uri(
         "api/movements/$agencyId/in?fromDateTime=" +
           "${fromDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}&toDateTime=" +
-          "${toDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}",
+          toDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
       )
       .header("Page-Limit", "10000")
       .retrieve()
       .bodyToMono(typeReference<List<Movement>>())
+      .onErrorResume(WebClientResponseException::class.java) {
+        Mono.just(emptyList())
+      }
       .block() ?: emptyList()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClient.kt
@@ -10,6 +10,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.config.ClientErrorResponse
 import uk.gov.justice.digital.hmpps.config.ClientException
+import uk.gov.justice.digital.hmpps.config.NotFoundException
 import uk.gov.justice.digital.hmpps.config.typeReference
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -306,7 +307,7 @@ class PrisonApiClient(
       .retrieve()
       .bodyToMono(typeReference<List<Movement>>())
       .onErrorResume(WebClientResponseException::class.java) {
-        Mono.just(emptyList())
+        throw NotFoundException("Could not find agency with agencyId: '$agencyId'")
       }
       .block() ?: emptyList()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
@@ -877,6 +877,46 @@ class PrisonApiMockServer : WireMockServer(9005) {
     )
   }
 
+  fun stubGetMovementSuccessButEmptyList(agencyId: String, fromDate: LocalDateTime, toDate: LocalDateTime) {
+    stubFor(
+      get(
+        "/api/movements/$agencyId/in?fromDateTime=${fromDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}" +
+          "&toDateTime=${toDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}",
+      )
+        .withHeader("Page-Limit", equalTo("10000"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .withStatus(200)
+            .withBody(
+              """
+              []
+              """.trimIndent(),
+            ),
+        ),
+    )
+  }
+
+  fun stubGetMovementEmptyListWhenServerError(agencyId: String, fromDate: LocalDateTime, toDate: LocalDateTime, status: Int) {
+    stubFor(
+      get(
+        "/api/movements/$agencyId/in?fromDateTime=${fromDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}" +
+          "&toDateTime=${toDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}",
+      )
+        .withHeader("Page-Limit", equalTo("10000"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .withStatus(status)
+            .withBody(
+              """
+              []
+              """.trimIndent(),
+            ),
+        ),
+    )
+  }
+
   fun stubGetAgencySuccess(agencyId: String) {
     stubFor(
       get("/api/agencies/$agencyId")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
@@ -907,12 +907,7 @@ class PrisonApiMockServer : WireMockServer(9005) {
         .willReturn(
           aResponse()
             .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-            .withStatus(status)
-            .withBody(
-              """
-              []
-              """.trimIndent(),
-            ),
+            .withStatus(status),
         ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
@@ -897,7 +897,7 @@ class PrisonApiMockServer : WireMockServer(9005) {
     )
   }
 
-  fun stubGetMovementEmptyListWhenServerError(agencyId: String, fromDate: LocalDateTime, toDate: LocalDateTime, status: Int) {
+  fun stubGetMovementWhenServerError(agencyId: String, fromDate: LocalDateTime, toDate: LocalDateTime, status: Int) {
     stubFor(
       get(
         "/api/movements/$agencyId/in?fromDateTime=${fromDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}" +

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
@@ -461,6 +461,30 @@ class PrisonApiClientTest {
   }
 
   @Test
+  fun `Get recent movements successful with empty list`() {
+    val agencyId = "MDI"
+    val fromDate = LocalDateTime.of(2020, 1, 18, 8, 0)
+    val toDate = LocalDateTime.of(2022, 1, 18, 8, 0)
+    mockServer.stubGetMovementSuccessButEmptyList(agencyId, fromDate, toDate)
+
+    val response = prisonApiClient.getMovement(agencyId, fromDate, toDate)
+
+    assertThat(response.size).isEqualTo(0)
+  }
+
+  @Test
+  fun `Get recent movements agency not found`() {
+    val agencyId = "XXX"
+    val fromDate = LocalDateTime.of(2020, 1, 18, 8, 0)
+    val toDate = LocalDateTime.of(2022, 1, 18, 8, 0)
+
+    mockServer.stubGetMovementEmptyListWhenServerError(agencyId, fromDate, toDate, 404)
+    val response = prisonApiClient.getMovement(agencyId, fromDate, toDate)
+    assertThat(response.size).isEqualTo(0)
+    assertThat(prisonApiClient.getMovement(agencyId, fromDate, toDate)).isNotNull()
+  }
+
+  @Test
   fun `Confirm return from temporary absences successful`() {
     val offenderNumber = "ABC123A"
     mockServer.stubConfirmTemporaryAbsencesSuccess(offenderNumber)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.springframework.http.HttpStatus
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.config.ClientException
 import uk.gov.justice.digital.hmpps.welcometoprison.integration.PrisonApiMockServer
@@ -24,6 +25,7 @@ class PrisonApiClientTest {
   private lateinit var prisonApiClient: PrisonApiClient
   private val telemetryClient: TelemetryClient = mock()
   val agencyId = "MDI"
+  val agencyIdInvalid = "XXX"
 
   companion object {
     @JvmField
@@ -185,21 +187,24 @@ class PrisonApiClientTest {
 
   @Test
   fun `create offender fails`() {
-    mockServer.stubCreateOffenderFails(400)
-    try {
-      prisonApiClient.createOffender(
-        CreateOffenderDetail(
-          firstName = "A",
-          lastName = "Z",
-          dateOfBirth = LocalDate.of(1961, 5, 29),
-          gender = "M",
-        ),
-      )
-    } catch (exception: RuntimeException) {
-      assertThat(exception.message)
-    }
-
-    verify(telemetryClient).trackEvent(eq("PrisonApiClientError"), any(), eq(null))
+    HttpStatus.entries
+      .filter { it.is4xxClientError }
+      .map {
+        mockServer.stubCreateOffenderFails(it.value())
+        try {
+          prisonApiClient.createOffender(
+            CreateOffenderDetail(
+              firstName = "A",
+              lastName = "Z",
+              dateOfBirth = LocalDate.of(1961, 5, 29),
+              gender = "M",
+            ),
+          )
+          verify(telemetryClient).trackEvent(eq("PrisonApiClientError"), any(), eq(null))
+        } catch (exception: RuntimeException) {
+          assertThat(exception.message)
+        }
+      }
   }
 
   @Test
@@ -223,19 +228,23 @@ class PrisonApiClientTest {
   fun `admit Offender On New Booking fails`() {
     val offenderNumber = "ABC123A"
 
-    mockServer.stubAdmitOnNewBookingFails(offenderNumber, 404)
+    HttpStatus.entries
+      .filter { it.is4xxClientError }
+      .map {
+        mockServer.stubAdmitOnNewBookingFails(offenderNumber, it.value())
 
-    assertThatThrownBy {
-      prisonApiClient.admitOffenderOnNewBooking(
-        offenderNumber,
-        AdmitOnNewBookingDetail(
-          prisonId = "NMI",
-          imprisonmentStatus = "SENT03",
-          movementReasonCode = "C",
-          youthOffender = false,
-        ),
-      )
-    }.isInstanceOf(ClientException::class.java)
+        assertThatThrownBy {
+          prisonApiClient.admitOffenderOnNewBooking(
+            offenderNumber,
+            AdmitOnNewBookingDetail(
+              prisonId = "NMI",
+              imprisonmentStatus = "SENT03",
+              movementReasonCode = "C",
+              youthOffender = false,
+            ),
+          )
+        }.isInstanceOf(ClientException::class.java)
+      }
   }
 
   @Test
@@ -295,19 +304,23 @@ class PrisonApiClientTest {
   fun `Recall offender fails`() {
     val offenderNumber = "ABC123A"
 
-    mockServer.stubRecallOffenderFails(offenderNumber, 404)
+    HttpStatus.entries
+      .filter { it.is4xxClientError }
+      .map {
+        mockServer.stubRecallOffenderFails(offenderNumber, it.value())
 
-    assertThatThrownBy {
-      prisonApiClient.recallOffender(
-        offenderNumber,
-        RecallBooking(
-          prisonId = "NMI",
-          imprisonmentStatus = "SENT03",
-          movementReasonCode = "C",
-          youthOffender = false,
-        ),
-      )
-    }.isInstanceOf(ClientException::class.java)
+        assertThatThrownBy {
+          prisonApiClient.recallOffender(
+            offenderNumber,
+            RecallBooking(
+              prisonId = "NMI",
+              imprisonmentStatus = "SENT03",
+              movementReasonCode = "C",
+              youthOffender = false,
+            ),
+          )
+        }.isInstanceOf(ClientException::class.java)
+      }
   }
 
   @Test
@@ -328,18 +341,23 @@ class PrisonApiClientTest {
   @Test
   fun `Transfer in offender fails`() {
     val offenderNumber = "ABC123A"
-    mockServer.stubTransferInOffenderFails(offenderNumber, 404)
 
-    assertThatThrownBy {
-      prisonApiClient.transferIn(
-        offenderNumber,
-        TransferIn(
-          cellLocation = "MDI-RECP",
-          commentText = "Prisoner was transferred to a new prison",
-          receiveTime = LocalDateTime.of(2021, 11, 15, 1, 0, 0),
-        ),
-      )
-    }.isInstanceOf(ClientException::class.java)
+    HttpStatus.entries
+      .filter { it.is4xxClientError }
+      .map {
+        mockServer.stubTransferInOffenderFails(offenderNumber, it.value())
+
+        assertThatThrownBy {
+          prisonApiClient.transferIn(
+            offenderNumber,
+            TransferIn(
+              cellLocation = "MDI-RECP",
+              commentText = "Prisoner was transferred to a new prison",
+              receiveTime = LocalDateTime.of(2021, 11, 15, 1, 0, 0),
+            ),
+          )
+        }.isInstanceOf(ClientException::class.java)
+      }
   }
 
   @Test
@@ -361,19 +379,23 @@ class PrisonApiClientTest {
   @Test
   fun `Transfer from Court fails`() {
     val offenderNumber = "A1234BC"
-    mockServer.stubCourtTransferInOffenderFails(offenderNumber, 404)
+    HttpStatus.entries
+      .filter { it.is4xxClientError }
+      .map {
+        mockServer.stubCourtTransferInOffenderFails(offenderNumber, it.value())
 
-    assertThatThrownBy {
-      prisonApiClient.courtTransferIn(
-        offenderNumber,
-        CourtTransferIn(
-          agencyId,
-          movementReasonCode = "CA",
-          commentText = "Prisoner was transferred from court",
-          dateTime = LocalDateTime.of(2021, 11, 15, 1, 0, 0),
-        ),
-      )
-    }.isInstanceOf(ClientException::class.java)
+        assertThatThrownBy {
+          prisonApiClient.courtTransferIn(
+            offenderNumber,
+            CourtTransferIn(
+              agencyId,
+              movementReasonCode = "CA",
+              commentText = "Prisoner was transferred from court",
+              dateTime = LocalDateTime.of(2021, 11, 15, 1, 0, 0),
+            ),
+          )
+        }.isInstanceOf(ClientException::class.java)
+      }
   }
 
   @Test
@@ -471,7 +493,6 @@ class PrisonApiClientTest {
 
   @Test
   fun `Get recent movements agency not found and throw 500 Server error`() {
-    val agencyIdInvalid = "XXX"
     val fromDate = LocalDateTime.of(2020, 1, 18, 8, 0)
     val toDate = LocalDateTime.of(2022, 1, 18, 8, 0)
     mockServer.stubGetMovementEmptyListWhenServerError(agencyIdInvalid, fromDate, toDate, 404)
@@ -503,22 +524,25 @@ class PrisonApiClientTest {
   fun `return from temporary absences fails`() {
     val offenderNumber = "ABC123A"
 
-    mockServer.stubErrorTemporaryAbsencesSuccess(offenderNumber, 400)
-    runCatching {
-      prisonApiClient.confirmTemporaryAbsencesArrival(
-        offenderNumber,
-        TemporaryAbsencesArrival(
-          agencyId = "NMI",
-          movementReasonCode = "ET",
-          commentText = "",
-          receiveTime = LocalDateTime.of(2021, 11, 15, 1, 0, 0),
-        ),
-      )
-    }.onFailure {
-      assertThat(it.localizedMessage).contains("No prisoner found for prisoner number $offenderNumber")
-    }
-
-    verify(telemetryClient).trackEvent(eq("PrisonApiClientError"), any(), eq(null))
+    HttpStatus.entries
+      .filter { it.is4xxClientError }
+      .map {
+        mockServer.stubErrorTemporaryAbsencesSuccess(offenderNumber, it.value())
+        runCatching {
+          prisonApiClient.confirmTemporaryAbsencesArrival(
+            offenderNumber,
+            TemporaryAbsencesArrival(
+              agencyId = "NMI",
+              movementReasonCode = "ET",
+              commentText = "",
+              receiveTime = LocalDateTime.of(2021, 11, 15, 1, 0, 0),
+            ),
+          )
+          verify(telemetryClient).trackEvent(eq("PrisonApiClientError"), any(), eq(null))
+        }.onFailure {
+          assertThat(it.localizedMessage).contains("No prisoner found for prisoner number $offenderNumber")
+        }
+      }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
@@ -492,10 +492,10 @@ class PrisonApiClientTest {
   }
 
   @Test
-  fun `Get recent movements agency not found and throw 500 Server error`() {
+  fun `Get recent movements agencyId not found`() {
     val fromDate = LocalDateTime.of(2020, 1, 18, 8, 0)
     val toDate = LocalDateTime.of(2022, 1, 18, 8, 0)
-    mockServer.stubGetMovementEmptyListWhenServerError(agencyIdInvalid, fromDate, toDate, 404)
+    mockServer.stubGetMovementWhenServerError(agencyIdInvalid, fromDate, toDate, 404)
 
     assertThatThrownBy {
       prisonApiClient.getMovement(agencyIdInvalid, fromDate, toDate)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.config.ClientException
+import uk.gov.justice.digital.hmpps.config.NotFoundException
 import uk.gov.justice.digital.hmpps.welcometoprison.integration.PrisonApiMockServer
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -477,11 +478,12 @@ class PrisonApiClientTest {
     val agencyId = "XXX"
     val fromDate = LocalDateTime.of(2020, 1, 18, 8, 0)
     val toDate = LocalDateTime.of(2022, 1, 18, 8, 0)
-
     mockServer.stubGetMovementEmptyListWhenServerError(agencyId, fromDate, toDate, 404)
-    val response = prisonApiClient.getMovement(agencyId, fromDate, toDate)
-    assertThat(response.size).isEqualTo(0)
-    assertThat(prisonApiClient.getMovement(agencyId, fromDate, toDate)).isNotNull()
+
+    assertThatThrownBy {
+      prisonApiClient.getMovement(agencyId, fromDate, toDate)
+      assertThat(prisonApiClient.getMovement(agencyId, fromDate, toDate)).isNotNull()
+    }.isInstanceOf(NotFoundException::class.java).hasMessage("Could not find agency with agencyId: '$agencyId'")
   }
 
   @Test


### PR DESCRIPTION
As I am looking to cover webClient line which might be due 4xx server error, 
![image](https://github.com/user-attachments/assets/d4108547-9d2a-43df-8a17-f79e853c245d)

As It's a Reactive Chain response we should handle the error however this mean logic change where we have to use **onErrorResume**

As Consumer might consume 500 server error I have capture that scenario where  Client gives 400 but there is a suppressor in the code returning 500.

plus a EmptyList return not already tested.

**Resources**
PRISON API SWAGGER https://prison-api-dev.prison.service.justice.gov.uk/swagger-ui/index.html#/

   