### PR TITLE
MAP-1460 PrisonApiClientTest getUserCaseLoads is4xxClientError scenario


### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
@@ -28,6 +28,17 @@ class PrisonApiMockServer : WireMockServer(9005) {
     )
   }
 
+  fun stubGetUserCaseLoads404() {
+    stubFor(
+      get("/api/users/me/caseLoads")
+        .willReturn(
+          aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withStatus(404),
+        ),
+    )
+  }
+
   fun stubGetPrisonTransfersEnRoute(prisonId: String, movementDate: LocalDate) {
     stubFor(
       get("/api/movements/$prisonId/enroute?movementDate=" + movementDate.format(DateTimeFormatter.ISO_LOCAL_DATE))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
@@ -760,6 +760,26 @@ class PrisonApiMockServer : WireMockServer(9005) {
     )
   }
 
+  fun stubErrorTemporaryAbsencesSuccess(offenderNo: String, status: Int) {
+    stubFor(
+      put("/api/offenders/$offenderNo/temporary-absence-arrival")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .withStatus(status)
+            .withBody(
+              """
+              {
+                "status": $status,
+                "userMessage": "No prisoner found for prisoner number $offenderNo",
+                "developerMessage": "No prisoner found for prisoner number $offenderNo"
+              }
+            """,
+            ),
+        ),
+    )
+  }
+
   fun stubGetMovementSuccess(agencyId: String, fromDate: LocalDateTime, toDate: LocalDateTime) {
     stubFor(
       get(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
@@ -28,13 +28,13 @@ class PrisonApiMockServer : WireMockServer(9005) {
     )
   }
 
-  fun stubGetUserCaseLoads404() {
+  fun stubGetUserCaseLoadsis4xxClientError(status: Int) {
     stubFor(
       get("/api/users/me/caseLoads")
         .willReturn(
           aResponse()
             .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
-            .withStatus(404),
+            .withStatus(status),
         ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
@@ -72,12 +72,16 @@ class PrisonApiClientTest {
   }
 
   @Test
-  fun `get user case loads 404`() {
-    mockServer.stubGetUserCaseLoads404()
-    assertThatThrownBy {
-      val userCaseLoads = prisonApiClient.getUserCaseLoads()
-      assertThat(userCaseLoads).isEmpty()
-    }.isInstanceOf(RuntimeException::class.java)
+  fun `get user case loads fails`() {
+    HttpStatus.entries
+      .filter { it.is4xxClientError }
+      .map {
+        mockServer.stubGetUserCaseLoadsis4xxClientError(it.value())
+        assertThatThrownBy {
+          val userCaseLoads = prisonApiClient.getUserCaseLoads()
+          assertThat(userCaseLoads).isEmpty()
+        }.isInstanceOf(RuntimeException::class.java)
+      }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
@@ -79,7 +79,6 @@ class PrisonApiClientTest {
         mockServer.stubGetUserCaseLoadsis4xxClientError(it.value())
         assertThatThrownBy {
           val userCaseLoads = prisonApiClient.getUserCaseLoads()
-          assertThat(userCaseLoads).isEmpty()
         }.isInstanceOf(RuntimeException::class.java)
       }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
@@ -78,7 +78,7 @@ class PrisonApiClientTest {
       .map {
         mockServer.stubGetUserCaseLoadsis4xxClientError(it.value())
         assertThatThrownBy {
-          val userCaseLoads = prisonApiClient.getUserCaseLoads()
+          prisonApiClient.getUserCaseLoads()
         }.isInstanceOf(RuntimeException::class.java)
       }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
@@ -478,6 +478,28 @@ class PrisonApiClientTest {
   }
 
   @Test
+  fun `return from temporary absences fails`() {
+    val offenderNumber = "ABC123A"
+
+    mockServer.stubErrorTemporaryAbsencesSuccess(offenderNumber, 400)
+    runCatching {
+      prisonApiClient.confirmTemporaryAbsencesArrival(
+        offenderNumber,
+        TemporaryAbsencesArrival(
+          agencyId = "NMI",
+          movementReasonCode = "ET",
+          commentText = "",
+          receiveTime = LocalDateTime.of(2021, 11, 15, 1, 0, 0),
+        ),
+      )
+    }.onFailure {
+      assertThat(it.localizedMessage).contains("No prisoner found for prisoner number $offenderNumber")
+    }
+
+    verify(telemetryClient).trackEvent(eq("PrisonApiClientError"), any(), eq(null))
+  }
+
+  @Test
   fun `Confirm get Agency Test`() {
     val agencyId = "AGE1"
     mockServer.stubGetAgencySuccess(agencyId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
@@ -71,6 +71,15 @@ class PrisonApiClientTest {
   }
 
   @Test
+  fun `get user case loads 404`() {
+    mockServer.stubGetUserCaseLoads404()
+    assertThatThrownBy {
+      val userCaseLoads = prisonApiClient.getUserCaseLoads()
+      assertThat(userCaseLoads).isEmpty()
+    }.isInstanceOf(RuntimeException::class.java)
+  }
+
+  @Test
   fun `get prison transfers en-route happy path`() {
     mockServer.stubGetPrisonTransfersEnRoute("NMI", LocalDate.now())
 


### PR DESCRIPTION
Method getUserCaseLoads wasn't covered for is4xxClientError scenario at PrisonApiClientTest 
I have added this test for that