### PR TITLE
MAP-1460 PrisonApiClient getMovement catch RunTimeError trigger by block  emptyList scenario 

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/PrisonApiMockServer.kt
@@ -877,6 +877,41 @@ class PrisonApiMockServer : WireMockServer(9005) {
     )
   }
 
+  fun stubGetMovementSuccessButEmptyList(agencyId: String, fromDate: LocalDateTime, toDate: LocalDateTime) {
+    stubFor(
+      get(
+        "/api/movements/$agencyId/in?fromDateTime=${fromDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}" +
+          "&toDateTime=${toDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}",
+      )
+        .withHeader("Page-Limit", equalTo("10000"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .withStatus(200)
+            .withBody(
+              """
+              []
+              """.trimIndent(),
+            ),
+        ),
+    )
+  }
+
+  fun stubGetMovementWhenServerError(agencyId: String, fromDate: LocalDateTime, toDate: LocalDateTime, status: Int) {
+    stubFor(
+      get(
+        "/api/movements/$agencyId/in?fromDateTime=${fromDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}" +
+          "&toDateTime=${toDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}",
+      )
+        .withHeader("Page-Limit", equalTo("10000"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .withStatus(status),
+        ),
+    )
+  }
+
   fun stubGetAgencySuccess(agencyId: String) {
     stubFor(
       get("/api/agencies/$agencyId")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/model/prison/PrisonApiClientTest.kt
@@ -24,6 +24,8 @@ import java.time.format.DateTimeFormatter
 class PrisonApiClientTest {
   private lateinit var prisonApiClient: PrisonApiClient
   private val telemetryClient: TelemetryClient = mock()
+  val agencyId = "MDI"
+  val agencyIdInvalid = "XXX"
 
   companion object {
     @JvmField
@@ -366,7 +368,7 @@ class PrisonApiClientTest {
     prisonApiClient.courtTransferIn(
       offenderNumber,
       CourtTransferIn(
-        agencyId = "MDI",
+        agencyId,
         movementReasonCode = "CA",
         commentText = "Prisoner was transferred from court",
         dateTime = LocalDateTime.of(2021, 11, 15, 1, 0, 0),
@@ -386,7 +388,7 @@ class PrisonApiClientTest {
           prisonApiClient.courtTransferIn(
             offenderNumber,
             CourtTransferIn(
-              agencyId = "MDI",
+              agencyId,
               movementReasonCode = "CA",
               commentText = "Prisoner was transferred from court",
               dateTime = LocalDateTime.of(2021, 11, 15, 1, 0, 0),
@@ -398,7 +400,6 @@ class PrisonApiClientTest {
 
   @Test
   fun `Get temporary absences successful`() {
-    val agencyId = "MDI"
     val temporaryAbsence = TemporaryAbsence(
       offenderNo = "G1310UO",
       firstName = "EGURZTOF",
@@ -459,7 +460,6 @@ class PrisonApiClientTest {
 
   @Test
   fun `Get recent movements successful`() {
-    val agencyId = "MDI"
     val fromDate = LocalDateTime.of(2020, 1, 18, 8, 0)
     val toDate = LocalDateTime.of(2022, 1, 18, 8, 0)
     mockServer.stubGetMovementSuccess(agencyId, fromDate, toDate)
@@ -471,7 +471,6 @@ class PrisonApiClientTest {
 
   @Test
   fun `Get recent movements successful without location`() {
-    val agencyId = "MDI"
     val fromDate = LocalDateTime.of(2020, 1, 18, 8, 0)
     val toDate = LocalDateTime.of(2022, 1, 18, 8, 0)
     mockServer.stubGetMovementSuccessWithNoLocation(agencyId, fromDate, toDate)
@@ -479,6 +478,29 @@ class PrisonApiClientTest {
     val response = prisonApiClient.getMovement(agencyId, fromDate, toDate)
 
     assertThat(response.size).isEqualTo(2)
+  }
+
+  @Test
+  fun `Get recent movements successful with empty list`() {
+    val fromDate = LocalDateTime.of(2020, 1, 18, 8, 0)
+    val toDate = LocalDateTime.of(2022, 1, 18, 8, 0)
+    mockServer.stubGetMovementSuccessButEmptyList(agencyId, fromDate, toDate)
+
+    val response = prisonApiClient.getMovement(agencyId, fromDate, toDate)
+
+    assertThat(response.size).isEqualTo(0)
+  }
+
+  @Test
+  fun `Get recent movements agencyId not found`() {
+    val fromDate = LocalDateTime.of(2020, 1, 18, 8, 0)
+    val toDate = LocalDateTime.of(2022, 1, 18, 8, 0)
+    mockServer.stubGetMovementWhenServerError(agencyIdInvalid, fromDate, toDate, 404)
+
+    assertThatThrownBy {
+      prisonApiClient.getMovement(agencyIdInvalid, fromDate, toDate)
+      assertThat(prisonApiClient.getMovement(agencyIdInvalid, fromDate, toDate)).isNotNull()
+    }.isInstanceOf(RuntimeException::class.java)
   }
 
   @Test
@@ -525,7 +547,6 @@ class PrisonApiClientTest {
 
   @Test
   fun `Confirm get Agency Test`() {
-    val agencyId = "AGE1"
     mockServer.stubGetAgencySuccess(agencyId)
     assertThat(prisonApiClient.getAgency(agencyId)).isNotNull
   }


### PR DESCRIPTION
This Pull Request is related with previous closed
 https://github.com/ministryofjustice/hmpps-welcome-people-into-prison-api/pull/259 as i have merged main i have created 