### PR TITLE
MAP-2393: Integrate DPR report for confirmed arrivals

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,16 @@ Fetch the newest changes from hmpps-kotlin-template calling `git fetch hmpps-kot
 Find out missing commits https://github.com/ministryofjustice/hmpps-template-kotlin/commits/main/ following `sync commit` above.
 Cherry Pick the changes by calling `git cherry-pick <<commit_id>>..<<commit_id>>` if you want to Cherry pick only one commit call `git cherry-pick <<commit_id>>`
 Resolve the conflict and update **sync date** and **sync commit** in README.md to guide the next person on what was done.  
+
+### DPR confirmed arrivals report
+This API is integrated with a DPR report for confirmed arrivals. The report is configured in 
+`resources/reports/arrivals-report.json`
+
+Example definition endpoint 
+
+``GET {{url}}/definitions/transactions/arrivals``
+
+Example report endpoint
+
+``GET {{url}}/reports/transactions/arrivals``
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,8 +21,10 @@ dependencies {
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv")
 
   implementation("org.apache.commons:commons-text:1.12.0")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
   implementation("commons-codec:commons-codec:1.16.1")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.4.3")
+  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:8.0.1")
 
   runtimeOnly("org.flywaydb:flyway-core")
   runtimeOnly("org.postgresql:postgresql")

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -18,5 +18,6 @@ generic-service:
     BASM_ENDPOINT_URL: "https://hmpps-book-secure-move-api-staging.apps.cloud-platform.service.justice.gov.uk"
     PRISONER_SEARCH_ENDPOINT_URL: "https://prisoner-search-dev.prison.service.justice.gov.uk"
     PRISON_REGISTER_ENDPOINT_URL: "https://prison-register-dev.hmpps.service.justice.gov.uk"
+    MANAGE_USERS_ENDPOINT_URL: "https://manage-users-api-dev.hmpps.service.justice.gov.uk"
 generic-prometheus-alerts:
   businessHoursOnly: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -18,5 +18,6 @@ generic-service:
     BASM_ENDPOINT_URL: "https://hmpps-book-secure-move-api-preprod.apps.cloud-platform.service.justice.gov.uk"
     PRISONER_SEARCH_ENDPOINT_URL: "https://prisoner-search-preprod.prison.service.justice.gov.uk"
     PRISON_REGISTER_ENDPOINT_URL: "https://prison-register-preprod.hmpps.service.justice.gov.uk"
+    MANAGE_USERS_ENDPOINT_URL: "https://manage-users-api-preprod.hmpps.service.justice.gov.uk"
 generic-prometheus-alerts:
   businessHoursOnly: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -15,6 +15,7 @@ generic-service:
     BASM_ENDPOINT_URL: "https://api.bookasecuremove.service.justice.gov.uk"
     PRISONER_SEARCH_ENDPOINT_URL: "https://prisoner-search.prison.service.justice.gov.uk"
     PRISON_REGISTER_ENDPOINT_URL: "https://prison-register.hmpps.service.justice.gov.uk"
+    MANAGE_USERS_ENDPOINT_URL: "https://manage-users-api.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/App.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/App.kt
@@ -6,6 +6,8 @@ import org.springframework.boot.runApplication
 @SpringBootApplication()
 class App
 
+const val SYSTEM_USERNAME = "WELCOME_PEOPLE_INTO_PRISON_API"
+
 fun main(args: Array<String>) {
   runApplication<App>(*args)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/config/ExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/config/ExceptionHandler.kt
@@ -12,9 +12,11 @@ import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.MissingRequestValueException
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.exception.UserAuthorisationException
 
 @RestControllerAdvice
 class ExceptionHandler {
@@ -147,6 +149,21 @@ class ExceptionHandler {
         ErrorResponse(
           status = INTERNAL_SERVER_ERROR.value(),
           userMessage = "Unexpected error",
+        ),
+      )
+  }
+
+  @ExceptionHandler(UserAuthorisationException::class)
+  @ResponseStatus(FORBIDDEN)
+  fun handleUserAuthorisationException(e: UserAuthorisationException): ResponseEntity<ErrorResponse> {
+    log.error("Access denied exception: {}", e.message)
+    return ResponseEntity
+      .status(FORBIDDEN)
+      .body(
+        ErrorResponse(
+          status = FORBIDDEN.value(),
+          userMessage = "User authorisation failure: ${e.message}",
+          developerMessage = e.message,
         ),
       )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/config/WebClientConfiguration.kt
@@ -17,6 +17,9 @@ import org.springframework.web.reactive.function.client.ExchangeFilterFunction
 import org.springframework.web.reactive.function.client.ExchangeFunction
 import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.SYSTEM_USERNAME
+import java.time.Duration
+import uk.gov.justice.hmpps.kotlin.auth.authorisedWebClient
 
 @Configuration
 class WebClientConfiguration(
@@ -24,7 +27,16 @@ class WebClientConfiguration(
   @Value("\${basm.endpoint.url}") private val basmRootUri: String,
   @Value("\${prisoner.search.endpoint.url}") private val prisonerSearchApiUrl: String,
   @Value("\${prison.register.endpoint.url}") private val prisonRegisterApiUrl: String,
+  @Value("\${manage.users.endpoint.url}") private val manageUsersApiUri: String,
+  @Value("\${api.timeout:20s}") val healthTimeout: Duration,
 ) {
+
+  @Bean
+  fun manageUsersHealthWebClient(): WebClient = WebClient.builder().baseUrl(manageUsersApiUri).build()
+
+  @Bean
+  fun manageUsersWebClient(authorizedClientManager: OAuth2AuthorizedClientManager): WebClient =
+    WebClient.builder().authorisedWebClient(authorizedClientManager, registrationId = SYSTEM_USERNAME, url = manageUsersApiUri, healthTimeout)
 
   @Bean
   fun prisonApiWebClient(): WebClient {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/config/WebClientConfiguration.kt
@@ -18,8 +18,8 @@ import org.springframework.web.reactive.function.client.ExchangeFunction
 import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.SYSTEM_USERNAME
-import java.time.Duration
 import uk.gov.justice.hmpps.kotlin.auth.authorisedWebClient
+import java.time.Duration
 
 @Configuration
 class WebClientConfiguration(
@@ -35,8 +35,7 @@ class WebClientConfiguration(
   fun manageUsersHealthWebClient(): WebClient = WebClient.builder().baseUrl(manageUsersApiUri).build()
 
   @Bean
-  fun manageUsersWebClient(authorizedClientManager: OAuth2AuthorizedClientManager): WebClient =
-    WebClient.builder().authorisedWebClient(authorizedClientManager, registrationId = SYSTEM_USERNAME, url = manageUsersApiUri, healthTimeout)
+  fun manageUsersWebClient(authorizedClientManager: OAuth2AuthorizedClientManager): WebClient = WebClient.builder().authorisedWebClient(authorizedClientManager, registrationId = SYSTEM_USERNAME, url = manageUsersApiUri, healthTimeout)
 
   @Bean
   fun prisonApiWebClient(): WebClient {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/config/health/HealthCheck.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/config/health/HealthCheck.kt
@@ -35,3 +35,6 @@ class PrisonerSearchApiHealth(@Qualifier("prisonerSearchApiHealthWebClient") web
 
 @Component
 class BasmApiHealth(@Qualifier("basmApiHealthWebClient") webClient: WebClient) : HealthCheck(webClient, "/ping")
+
+@Component
+class ManageUsersApiHealth(@Qualifier("manageUsersHealthWebClient") webClient: WebClient) : HealthCheck(webClient, "/health/ping")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,15 +58,29 @@ spring:
             client-id: ${basm.client.client-id}
             client-secret: ${basm.client.client-secret}
             authorization-grant-type: client_credentials
+          WELCOME_PEOPLE_INTO_PRISON_API:
+            provider: hmpps-auth
+            client-id: ${welcome_people_into_prison.api.client.id}
+            client-secret: ${welcome_people_into_prison.api.client.secret}
+            authorization-grant-type: client_credentials
         provider:
           basm-auth:
             token-uri: ${basm.endpoint.url}/oauth/token
+          hmpps-auth:
+            token-uri: ${oauth.endpoint.url}/oauth/token
   data:
     jdbc:
       dialect: postgresql
   sql:
     init:
       continue-on-error: true
+
+dpr:
+  lib:
+    definition:
+      locations: "reports/arrivals-report.json"
+    system:
+      role: DPR_API_ACCESS
 
 server:
   port: 8080

--- a/src/main/resources/reports/arrivals-report.json
+++ b/src/main/resources/reports/arrivals-report.json
@@ -25,7 +25,7 @@
             {
               "match": [
                 "${role}",
-                "VIEW_ARRIVALS"
+                "MANAGE_RES_LOCATIONS_OP_CAP"
               ]
             }
           ]
@@ -53,7 +53,7 @@
       "id": "arrivals",
       "name": "Transactions for confirmed arrivals",
       "datasource": "dataSource",
-      "query": "ca.prison_id, ca.\"timestamp\" as arrival_time, ca.arrival_type, ca.username from confirmed_arrival ca",
+      "query": "select ca.prison_id, ca.\"timestamp\" as arrival_time, ca.arrival_type, ca.username from confirmed_arrival ca",
       "schema": {
         "field": [
           {
@@ -119,7 +119,7 @@
           {
             "name": "$ref:arrival_time",
             "display": "Arrival time",
-            "formula": "format_date(${tx_start_time}, 'dd/MM/yyyy HH:mm')",
+            "formula": "format_date(${arrival_time}, 'dd/MM/yyyy HH:mm')",
             "sortable": true,
             "visible": "true",
             "defaultsort": true,

--- a/src/main/resources/reports/arrivals-report.json
+++ b/src/main/resources/reports/arrivals-report.json
@@ -1,7 +1,7 @@
 {
   "id": "transactions",
   "name": "Transactions for WPIP",
-  "description": "List of confirmed in WPIP",
+  "description": "List of confirmed arrivals in WPIP",
   "metadata": {
     "author": "Dafydd Houston",
     "version": "1.0.0",

--- a/src/main/resources/reports/arrivals-report.json
+++ b/src/main/resources/reports/arrivals-report.json
@@ -1,0 +1,155 @@
+{
+  "id": "transactions",
+  "name": "Transactions for WPIP",
+  "description": "List of confirmed in WPIP",
+  "metadata": {
+    "author": "Dafydd Houston",
+    "version": "1.0.0",
+    "owner": "Move a prisoner team"
+  },
+  "datasource": [
+    {
+      "id": "irs",
+      "name": "dataSource",
+      "connection": "postgres"
+    }
+  ],
+  "policy": [
+    {
+      "id": "access",
+      "type": "access",
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": [
+            {
+              "match": [
+                "${role}",
+                "VIEW_ARRIVALS"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "caseloads",
+      "type": "row-level",
+      "action": ["prison_id IN (${caseloads})"],
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": [
+            {
+              "exists": ["${caseloads}"]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "dataset": [
+    {
+      "id": "arrivals",
+      "name": "Transactions for confirmed arrivals",
+      "datasource": "dataSource",
+      "query": "ca.prison_id, ca.\"timestamp\" as arrival_time, ca.arrival_type, ca.username from confirmed_arrival ca",
+      "schema": {
+        "field": [
+          {
+            "name": "prison_id",
+            "type": "string"
+          },
+          {
+            "name": "arrival_time",
+            "type": "datetime"
+          },
+          {
+            "name": "arrival_type",
+            "type": "string",
+            "filter": {
+              "type": "multiselect",
+              "staticoptions": [
+                {"name": "COURT_TRANSFER", "display": "Court transfer"},
+                {"name": "NEW_BOOKING_EXISTING_OFFENDER", "display": "New booking (Existing offender)"},
+                {"name": "NEW_TO_PRISON", "display": "New to prison"},
+                {"name": "RECALL", "display": "Recall"},
+                {"name": "TEMPORARY_ABSENCE", "display": "Temporary absense"},
+                {"name": "TRANSFER", "display": "Transfer"}
+              ]
+            }
+          },
+          {
+            "name": "username",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "report": [
+    {
+      "id": "arrivals",
+      "name": "Transactions for WPIP",
+      "description": "Details each confirmed arrival that has occurred in a prison",
+      "version": "1.0.0",
+      "dataset": "$ref:arrivals",
+      "policy": [],
+      "render": "HTML",
+      "feature": [
+        {
+          "type": "print"
+        }
+      ],
+      "specification": {
+        "template": "list",
+        "field": [
+          {
+            "name": "$ref:prison_id",
+            "display": "Prison ID",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false,
+
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false
+            }
+          },
+          {
+            "name": "$ref:arrival_time",
+            "display": "Arrival time",
+            "formula": "format_date(${tx_start_time}, 'dd/MM/yyyy HH:mm')",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": true,
+            "filter": {
+              "type": "daterange",
+              "default": "today(-1,months) - today()"
+            }
+          },
+          {
+            "name": "$ref:arrival_type",
+            "display": "Arrival type",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:username",
+            "display": "User name",
+            "sortable": false,
+            "visible": "false",
+            "defaultsort": false
+          }
+        ]
+      },
+      "destination": [],
+      "summary": [{
+        "id": "summaryId",
+        "template": "page-header",
+        "dataset": "$ref:arrivals"
+      }]
+    }
+  ]
+}

--- a/src/main/resources/reports/arrivals-report.json
+++ b/src/main/resources/reports/arrivals-report.json
@@ -25,7 +25,7 @@
             {
               "match": [
                 "${role}",
-                "MANAGE_RES_LOCATIONS_OP_CAP"
+                "PRISONS_REPORTING_USER"
               ]
             }
           ]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/archunit/ArchUnitTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/archunit/ArchUnitTest.kt
@@ -17,6 +17,7 @@ class ArchUnitTest {
         "..uk.gov.justice.digital.hmpps.bodyscan..",
         "..uk.gov.justice.digital.hmpps.archunit..",
         "..uk.gov.justice.digital.hmpps.config..",
+        "..uk.gov.justice.digital.hmpps.digitalprisonreportinglib..",
       )
 
     rule.orShould().haveSimpleName("App")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/config/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/config/JwtAuthHelper.kt
@@ -26,7 +26,7 @@ class JwtAuthHelper {
   fun jwtDecoder(): JwtDecoder = NimbusJwtDecoder.withPublicKey(keyPair.public as RSAPublicKey).build()
 
   fun setAuthorisation(
-    user: String,
+    user: String?,
     roles: List<String> = listOf(),
     scopes: List<String> = listOf(),
   ): (HttpHeaders) -> Unit {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/config/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/config/JwtAuthHelper.kt
@@ -29,12 +29,14 @@ class JwtAuthHelper {
     user: String?,
     roles: List<String> = listOf(),
     scopes: List<String> = listOf(),
+    clientId: String = "test-client-id",
   ): (HttpHeaders) -> Unit {
     val token = createJwt(
       subject = user,
       scope = scopes,
       expiryTime = Duration.ofHours(1L),
       roles = roles,
+      clientId = clientId,
     )
     return { it.set(HttpHeaders.AUTHORIZATION, "Bearer $token") }
   }
@@ -43,31 +45,43 @@ class JwtAuthHelper {
     user: String,
     roles: List<String> = listOf(),
     scopes: List<String> = listOf(),
+    clientId: String = "test-client-id",
   ): String {
     val token = createJwt(
       subject = user,
       scope = scopes,
       expiryTime = Duration.ofHours(1L),
       roles = roles,
+      clientId = clientId,
     )
     return "Bearer $token"
   }
 
   internal fun createJwt(
+    clientId: String,
     subject: String?,
     scope: List<String>? = listOf(),
     roles: List<String>? = listOf(),
     expiryTime: Duration = Duration.ofHours(1),
     jwtId: String = UUID.randomUUID().toString(),
-  ): String = mutableMapOf<String, Any>()
-    .also { subject?.let { subject -> it["user_name"] = subject } }
-    .also { it["client_id"] = "court-reg-client" }
-    .also { roles?.let { roles -> it["authorities"] = roles } }
-    .also { scope?.let { scope -> it["scope"] = scope } }
+    authSource: String = "none",
+    grantType: String = "client_credentials",
+  ): String = mutableMapOf<String, Any>(
+    "sub" to (subject ?: clientId),
+    "client_id" to clientId,
+    "auth_source" to authSource,
+    "grant_type" to grantType,
+  ).apply {
+    subject?.let { this["user_name"] = subject }
+    scope?.let { this["scope"] = scope }
+    roles?.let {
+      this["authorities"] = roles.map { "ROLE_${it.substringAfter("ROLE_")}" }
+    }
+  }
     .let {
       Jwts.builder()
         .id(jwtId)
-        .subject(subject)
+        .subject(subject ?: clientId)
         .claims(it.toMap())
         .expiration(Date(System.currentTimeMillis() + expiryTime.toMillis()))
         .signWith(keyPair.private)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/HmppsAuthMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/HmppsAuthMockServer.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.welcometoprison.integration
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.http.HttpHeader
+import com.github.tomakehurst.wiremock.http.HttpHeaders
+
+class HmppsAuthMockServer : WireMockServer(WIREMOCK_PORT) {
+  companion object {
+    private const val WIREMOCK_PORT = 8090
+  }
+
+  fun stubGrantToken() {
+    stubFor(
+      post(urlEqualTo("/auth/oauth/token"))
+        .willReturn(
+          aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(
+              """{
+                    "token_type": "bearer",
+                    "access_token": "ABCDE"
+                }
+              """.trimIndent(),
+            ),
+        ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/IntegrationTestBase.kt
@@ -88,10 +88,11 @@ abstract class IntegrationTestBase {
   internal fun <S : RequestHeadersSpec<S>?> RequestHeadersSpec<S>.withBearerToken(token: String) = this.apply { header(AUTHORIZATION, token) }
 
   internal fun setAuthorisation(
+    clientId: String = "test-client-id",
     user: String? = "welcome-into-prison-client",
     roles: List<String> = listOf(),
     scopes: List<String> = listOf(),
-  ): (HttpHeaders) -> Unit = jwtAuthHelper.setAuthorisation(user, roles, scopes)
+  ): (HttpHeaders) -> Unit = jwtAuthHelper.setAuthorisation(user, roles, scopes, clientId = clientId)
 
   internal fun getAuthorisation(
     roles: List<String> = listOf(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/IntegrationTestBase.kt
@@ -40,6 +40,8 @@ abstract class IntegrationTestBase {
     internal val prisonApiMockServer = PrisonApiMockServer()
     internal val prisonRegisterMockServer = PrisonRegisterMockServer()
     internal val prisonerSearchMockServer = PrisonerSearchMockServer()
+    internal val manageUsersApiMockServer = ManageUsersApiMockServer()
+    internal val hmppsAuthMockServer = HmppsAuthMockServer()
 
     @BeforeAll
     @JvmStatic
@@ -53,6 +55,9 @@ abstract class IntegrationTestBase {
       prisonRegisterMockServer.start()
       prisonerSearchMockServer.start()
       prisonerSearchMockServer.stubMatchPrisoners(200)
+      manageUsersApiMockServer.start()
+      hmppsAuthMockServer.start()
+      hmppsAuthMockServer.stubGrantToken()
     }
 
     @AfterAll
@@ -62,6 +67,8 @@ abstract class IntegrationTestBase {
       prisonApiMockServer.stop()
       prisonRegisterMockServer.stop()
       prisonerSearchMockServer.stop()
+      manageUsersApiMockServer.stop()
+      hmppsAuthMockServer.stop()
     }
   }
 
@@ -75,14 +82,16 @@ abstract class IntegrationTestBase {
     prisonApiMockServer.resetAll()
     prisonRegisterMockServer.resetAll()
     prisonerSearchMockServer.resetAll()
+    manageUsersApiMockServer.resetAll()
   }
 
   internal fun <S : RequestHeadersSpec<S>?> RequestHeadersSpec<S>.withBearerToken(token: String) = this.apply { header(AUTHORIZATION, token) }
 
   internal fun setAuthorisation(
+    user: String? = "welcome-into-prison-client",
     roles: List<String> = listOf(),
     scopes: List<String> = listOf(),
-  ): (HttpHeaders) -> Unit = jwtAuthHelper.setAuthorisation("welcome-into-prison-client", roles, scopes)
+  ): (HttpHeaders) -> Unit = jwtAuthHelper.setAuthorisation(user, roles, scopes)
 
   internal fun getAuthorisation(
     roles: List<String> = listOf(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/ManageUsersApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/ManageUsersApiMockServer.kt
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.hmpps.welcometoprison.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+
+class ManageUsersApiMockServer : WireMockServer(WIREMOCK_PORT) {
+  companion object {
+    private const val WIREMOCK_PORT = 9007
+  }
+
+  private val mapper = ObjectMapper().findAndRegisterModules()
+
+  fun stubLookupUserCaseload(
+    username: String = "request-user",
+    activeCaseload: String = "LEI",
+    otherCaseloads: List<String> = emptyList(),
+  ) {
+    val otherCaseloadJson: String = otherCaseloads.joinToString { ",{\"id\": \"$it\", \"name\": \"$it\"}" }
+    val payload = """
+        {
+          "username": "$username",
+          "active": true,
+          "accountType": "GENERAL",
+          "activeCaseload": { "id": "$activeCaseload", "name": "$activeCaseload" },
+          "caseloads": [
+            {
+              "id": "$activeCaseload",
+              "name": "$activeCaseload"
+            }
+             $otherCaseloadJson
+          ]
+        }
+    """.trimIndent()
+    stubFor(
+      get("/prisonusers/$username/caseloads")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(payload).withStatus(200),
+        ),
+    )
+  }
+
+  fun stubLookupUsersRoles(username: String = "request-user", roles: List<String> = emptyList()) {
+    stubFor(
+      get("/users/$username/roles")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(mapper.writeValueAsBytes(roles.map { RolesResponse(it) })).withStatus(200),
+        ),
+    )
+  }
+
+  data class RolesResponse(
+    val roleCode: String,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/health/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/integration/health/HealthCheckTest.kt
@@ -26,6 +26,7 @@ class HealthCheckTest : IntegrationTestBase() {
       .jsonPath("components.prisonApiHealth.details.HttpStatus").isEqualTo("OK")
       .jsonPath("components.prisonRegisterHealth.details.HttpStatus").isEqualTo("OK")
       .jsonPath("components.prisonerSearchApiHealth.details.HttpStatus").isEqualTo("OK")
+      .jsonPath("components.manageUsersApiHealth.details.HttpStatus").isEqualTo("OK")
   }
 
   @Test
@@ -145,6 +146,25 @@ class HealthCheckTest : IntegrationTestBase() {
     )
 
     prisonerSearchMockServer.stubFor(
+      get("/health/ping").willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withBody(
+            if (status == 200) {
+              """
+                {
+                  "status": "UP"
+                }
+              """.trimIndent()
+            } else {
+              "some error"
+            },
+          )
+          .withStatus(status),
+      ),
+    )
+
+    manageUsersApiMockServer.stubFor(
       get("/health/ping").willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/DprReportingResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/DprReportingResourceTest.kt
@@ -1,0 +1,67 @@
+package uk.gov.justice.digital.hmpps.welcometoprison.resource
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Value
+import uk.gov.justice.digital.hmpps.welcometoprison.integration.IntegrationTestBase
+
+private const val REQUESTING_USER = "request-user"
+
+class DprReportingResourceTest : IntegrationTestBase() {
+  @Value("\${dpr.lib.system.role}")
+  lateinit var systemRole: String
+
+  @BeforeEach
+  fun setUp() {
+    manageUsersApiMockServer.stubLookupUsersRoles(REQUESTING_USER, listOf("VIEW_ARRIVALS"))
+    manageUsersApiMockServer.stubLookupUserCaseload(REQUESTING_USER, "LEI", listOf("MDI"))
+  }
+
+  @DisplayName("GET /definitions")
+  @Nested
+  inner class GetDefinitions {
+    private val url = "/definitions"
+
+    @DisplayName("works")
+    @Nested
+    inner class HappyPath {
+
+      @Test
+      fun `returns the definitions of all the reports`() {
+        webTestClient.get().uri(url)
+          .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().jsonPath("$.length()").isEqualTo(1)
+          .jsonPath("$[0].authorised").isEqualTo("true")
+      }
+
+      @Test
+      fun `returns the definitions of all the reports but not authorises as no user in context`() {
+        webTestClient.get().uri(url)
+          .headers(setAuthorisation(user = null, roles = listOf(systemRole), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().jsonPath("$.length()").isEqualTo(1)
+          .jsonPath("$[0].authorised").isEqualTo("false")
+      }
+
+      @Test
+      fun `returns the not auth definitions of the reports`() {
+        manageUsersApiMockServer.stubLookupUsersRoles(REQUESTING_USER, listOf("ANOTHER_USER_ROLE"))
+
+        webTestClient.get().uri(url)
+          .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.length()").isEqualTo(1)
+          .jsonPath("$[0].authorised").isEqualTo("false")
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/DprReportingResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/DprReportingResourceTest.kt
@@ -1,21 +1,35 @@
 package uk.gov.justice.digital.hmpps.welcometoprison.resource
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.json.JsonCompareMode
 import uk.gov.justice.digital.hmpps.welcometoprison.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.welcometoprison.model.confirmedarrivals.ConfirmedArrivalRepository
 
 private const val REQUESTING_USER = "request-user"
+private const val CLIENT_ID = "hmpps-welcome-people-into-prison-api"
 
 class DprReportingResourceTest : IntegrationTestBase() {
   @Value("\${dpr.lib.system.role}")
   lateinit var systemRole: String
 
+  @Autowired
+  lateinit var repository: ConfirmedArrivalRepository
+
   @BeforeEach
   fun setUp() {
-    manageUsersApiMockServer.stubLookupUsersRoles(REQUESTING_USER, listOf("VIEW_ARRIVALS"))
+    manageUsersApiMockServer.stubLookupUsersRoles(REQUESTING_USER, listOf("MANAGE_RES_LOCATIONS_OP_CAP"))
     manageUsersApiMockServer.stubLookupUserCaseload(REQUESTING_USER, "LEI", listOf("MDI"))
+  }
+
+  @AfterEach
+  fun afterEach() {
+    repository.deleteAll()
   }
 
   @DisplayName("GET /definitions")
@@ -30,7 +44,7 @@ class DprReportingResourceTest : IntegrationTestBase() {
       @Test
       fun `returns the definitions of all the reports`() {
         webTestClient.get().uri(url)
-          .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read")))
+          .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read"), clientId = CLIENT_ID))
           .header("Content-Type", "application/json")
           .exchange()
           .expectStatus().isOk
@@ -41,7 +55,7 @@ class DprReportingResourceTest : IntegrationTestBase() {
       @Test
       fun `returns the definitions of all the reports but not authorises as no user in context`() {
         webTestClient.get().uri(url)
-          .headers(setAuthorisation(user = null, roles = listOf(systemRole), scopes = listOf("read")))
+          .headers(setAuthorisation(user = null, roles = listOf(systemRole), scopes = listOf("read"), clientId = CLIENT_ID))
           .header("Content-Type", "application/json")
           .exchange()
           .expectStatus().isOk
@@ -54,13 +68,132 @@ class DprReportingResourceTest : IntegrationTestBase() {
         manageUsersApiMockServer.stubLookupUsersRoles(REQUESTING_USER, listOf("ANOTHER_USER_ROLE"))
 
         webTestClient.get().uri(url)
-          .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read")))
+          .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read"), clientId = CLIENT_ID))
           .header("Content-Type", "application/json")
           .exchange()
           .expectStatus().isOk
           .expectBody()
           .jsonPath("$.length()").isEqualTo(1)
           .jsonPath("$[0].authorised").isEqualTo("false")
+      }
+    }
+  }
+
+  @DisplayName("GET /definitions/transactions/arrivals")
+  @Nested
+  inner class GetDefinitionDetails {
+    private val url = "/definitions/transactions/arrivals"
+
+    @Test
+    fun `report definition denied when user has incorrect role`() {
+      manageUsersApiMockServer.stubLookupUsersRoles(REQUESTING_USER, listOf("ANOTHER_USER_ROLE"))
+
+      webTestClient.get().uri(url)
+        .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read"), clientId = CLIENT_ID))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @DisplayName("works")
+    @Nested
+    inner class HappyPath {
+
+      @Test
+      fun `returns the definition of the report`() {
+        webTestClient.get().uri(url)
+          .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read"), clientId = CLIENT_ID))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .json(
+            // language=json
+            """
+           {
+              "id": "transactions",
+              "name": "Transactions for WPIP",
+              "description": "List of confirmed in WPIP",
+              "variant": {
+                "id": "arrivals",
+                "name": "Transactions for WPIP",
+                "resourceName": "reports/transactions/arrivals",
+                "description": "Details each confirmed arrival that has occurred in a prison",
+                "printable": true
+              }
+            }
+            """,
+          )
+      }
+    }
+  }
+
+  @DisplayName("GET /reports")
+  @Nested
+  inner class GetReports {
+    @DisplayName("GET /reports/transactions/arrivals")
+    @Nested
+    inner class RunTransactionReport {
+      private val url = "/reports/transactions/arrivals"
+
+      @Test
+      fun `returns 403 when user does not have the role`() {
+        manageUsersApiMockServer.stubLookupUsersRoles(REQUESTING_USER, listOf("ANOTHER_USER_ROLE"))
+
+        webTestClient.get().uri(url)
+          .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read"), clientId = CLIENT_ID))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @DisplayName("works")
+      @Nested
+      inner class HappyPath {
+
+        @Test
+        @Sql("classpath:repository/confirmed-arrival.sql")
+        fun `returns a page of the report`() {
+          webTestClient.get().uri(url)
+            .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read"), clientId = CLIENT_ID))
+            .header("Content-Type", "application/json")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody().json(
+              // language=json
+              """
+            [
+              {
+                "prison_id": "MDI",
+                "arrival_time": "01/01/2020 01:01",
+                "arrival_type": "NEW_TO_PRISON",
+                "username": "xyz"
+              },
+              {
+                "prison_id": "MDI",
+                "arrival_time": "02/01/2020 01:01",
+                "arrival_type": "NEW_TO_PRISON",
+                "username": "zzzz"
+              }
+            ]
+          """,
+              JsonCompareMode.LENIENT,
+            )
+        }
+
+        @Test
+        @Sql("classpath:repository/confirmed-arrival.sql")
+        fun `returns no data when user does not have the caseload`() {
+          manageUsersApiMockServer.stubLookupUserCaseload(REQUESTING_USER, "BXI", listOf("BXI"))
+
+          webTestClient.get().uri(url)
+            .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read"), clientId = CLIENT_ID))
+            .header("Content-Type", "application/json")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$.length()").isEqualTo(0)
+        }
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/DprReportingResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/DprReportingResourceTest.kt
@@ -113,7 +113,7 @@ class DprReportingResourceTest : IntegrationTestBase() {
            {
               "id": "transactions",
               "name": "Transactions for WPIP",
-              "description": "List of confirmed in WPIP",
+              "description": "List of confirmed arrivals in WPIP",
               "variant": {
                 "id": "arrivals",
                 "name": "Transactions for WPIP",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/DprReportingResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/welcometoprison/resource/DprReportingResourceTest.kt
@@ -23,7 +23,7 @@ class DprReportingResourceTest : IntegrationTestBase() {
 
   @BeforeEach
   fun setUp() {
-    manageUsersApiMockServer.stubLookupUsersRoles(REQUESTING_USER, listOf("MANAGE_RES_LOCATIONS_OP_CAP"))
+    manageUsersApiMockServer.stubLookupUsersRoles(REQUESTING_USER, listOf("PRISONS_REPORTING_USER"))
     manageUsersApiMockServer.stubLookupUserCaseload(REQUESTING_USER, "LEI", listOf("MDI"))
   }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -14,6 +14,9 @@ prison:
 prisoner:
   search.endpoint.url: http://localhost:8093
 
+manage:
+  users.endpoint.url: http://localhost:9007
+
 management.endpoint:
   health.cache.time-to-live: 0
   info.cache.time-to-live: 0


### PR DESCRIPTION
A DPR report to allow searable confirmed arrivals

1. Integration of the DPR reporting library
2. A report to detail confirmed arrivals
3. Integration of the DPR definitions and reporting endpoints
4. Add the manage users API required by DPR
5. Report uses the PRISONS_REPORTING_USER role
6. Reworked the test function createJwt to work with DPR