### PR TITLE
MAP-2467: updating dependencies. The swagger error message

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv")
 
   implementation("org.apache.commons:commons-text:1.12.0")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
   implementation("commons-codec:commons-codec:1.16.1")
   implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.4.3")
   implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:8.0.1")


### PR DESCRIPTION
Handler dispatch failed: java.lang.NoSuchMethodError: 'void org.springdoc.core.service.OpenAPIService.setServerBaseUrl(java.lang.String, org.springframework.http.HttpRequest)

is present in version 2.8.5 but not in 2.8.6.